### PR TITLE
Seeding all unique cities to our MongoDB

### DIFF
--- a/data-seeding/1-cities/index.js
+++ b/data-seeding/1-cities/index.js
@@ -1,52 +1,12217 @@
-module.exports = [
-  {
-    name: "Seattle, WA",
-    cost_of_living: "98%",
-    avg_commute_time: 23
-  },
-  {
-    name: "Mountain View, CA",
-    cost_of_living: "93%",
-    avg_commute_time: 15
-  },
-  {
-    name: "Los Angeles, CA",
-    cost_of_living: "78%",
-    avg_commute_time: 40
-  },
-  {
-    name: "Long Beach, CA",
-    cost_of_living: "68%",
-    avg_commute_time: 20
-  },
-  {
-    name: "Mesa, AZ",
-    cost_of_living: "68%",
-    avg_commute_time: 20
-  },
-  {
-    name: "Salt Lake City, UT",
-    cost_of_living: "38%",
-    avg_commute_time: 34
-  },
-  {
-    name: "San Jose, CA",
-    cost_of_living: "98%",
-    avg_commute_time: 24
-  },
-  {
-    name: "Tampa, FL",
-    cost_of_living: "88%",
-    avg_commute_time: 44
-  },
-  {
-    name: "San Antonio, TX",
-    cost_of_living: "98%",
-    avg_commute_time: 54
-  },
-  {
-    name: "Las Vegas, NV",
-    cost_of_living: "71%",
-    avg_commute_time: 28
+dataUsa = {
+  data: [
+    {
+      "ID Place": "16000US1270600",
+      Place: "Tallahassee, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.22637785313022,
+      "Slug Place": "tallahassee-fl"
+    },
+    {
+      "ID Place": "16000US7276770",
+      Place: "San Juan, PR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.11621049710341,
+      "Slug Place": "san-juan-pr"
+    },
+    {
+      "ID Place": "16000US4261000",
+      Place: "Pittsburgh, PA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.11057084253501,
+      "Slug Place": "pittsburgh-pa"
+    },
+    {
+      "ID Place": "16000US0107000",
+      Place: "Birmingham, AL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.56144844289174,
+      "Slug Place": "birmingham-al"
+    },
+    {
+      "ID Place": "16000US0121184",
+      Place: "Dothan, AL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.457877539423215,
+      "Slug Place": "dothan-al"
+    },
+    {
+      "ID Place": "16000US4263624",
+      Place: "Reading, PA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.09981690221434,
+      "Slug Place": "reading-pa"
+    },
+    {
+      "ID Place": "16000US0137000",
+      Place: "Huntsville, AL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.080298887884368,
+      "Slug Place": "huntsville-al"
+    },
+    {
+      "ID Place": "16000US4260000",
+      Place: "Philadelphia, PA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.73856298837431,
+      "Slug Place": "philadelphia-pa"
+    },
+    {
+      "ID Place": "16000US4224000",
+      Place: "Erie, PA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.030291632187367,
+      "Slug Place": "erie-pa"
+    },
+    {
+      "ID Place": "16000US0150000",
+      Place: "Mobile, AL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.008753446594344,
+      "Slug Place": "mobile-al"
+    },
+    {
+      "ID Place": "16000US4202000",
+      Place: "Allentown, PA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.756434981108313,
+      "Slug Place": "allentown-pa"
+    },
+    {
+      "ID Place": "16000US4164900",
+      Place: "Salem, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.19478155339806,
+      "Slug Place": "salem-or"
+    },
+    {
+      "ID Place": "16000US4159000",
+      Place: "Portland, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.705311007731108,
+      "Slug Place": "portland-or"
+    },
+    {
+      "ID Place": "16000US4134100",
+      Place: "Hillsboro, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.068183759588607,
+      "Slug Place": "hillsboro-or"
+    },
+    {
+      "ID Place": "16000US0203000",
+      Place: "Anchorage, AK",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.441059663310238,
+      "Slug Place": "anchorage-ak"
+    },
+    {
+      "ID Place": "16000US4459000",
+      Place: "Providence, RI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.269759917008347,
+      "Slug Place": "providence-ri"
+    },
+    {
+      "ID Place": "16000US4131250",
+      Place: "Gresham, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.714285714285715,
+      "Slug Place": "gresham-or"
+    },
+    {
+      "ID Place": "16000US4123850",
+      Place: "Eugene, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.602865183531865,
+      "Slug Place": "eugene-or"
+    },
+    {
+      "ID Place": "16000US0412000",
+      Place: "Chandler, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.926528241614637,
+      "Slug Place": "chandler-az"
+    },
+    {
+      "ID Place": "16000US4105350",
+      Place: "Beaverton, OR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.475635845020204,
+      "Slug Place": "beaverton-or"
+    },
+    {
+      "ID Place": "16000US4075000",
+      Place: "Tulsa, OK",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.61989946227712,
+      "Slug Place": "tulsa-ok"
+    },
+    {
+      "ID Place": "16000US4513330",
+      Place: "Charleston, SC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.119965496649193,
+      "Slug Place": "charleston-sc"
+    },
+    {
+      "ID Place": "16000US0427400",
+      Place: "Gilbert, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.114786165921284,
+      "Slug Place": "gilbert-az"
+    },
+    {
+      "ID Place": "16000US7206593",
+      Place: "Bayamón, PR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.75734240687679,
+      "Slug Place": "bayamón-pr"
+    },
+    {
+      "ID Place": "16000US4055000",
+      Place: "Oklahoma City, OK",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.71675755717622,
+      "Slug Place": "oklahoma-city-ok"
+    },
+    {
+      "ID Place": "16000US4052500",
+      Place: "Norman, OK",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.883570852379673,
+      "Slug Place": "norman-ok"
+    },
+    {
+      "ID Place": "16000US0427820",
+      Place: "Glendale, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.11467155157919,
+      "Slug Place": "glendale-az"
+    },
+    {
+      "ID Place": "16000US3977000",
+      Place: "Toledo, OH",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.621642625946897,
+      "Slug Place": "toledo-oh"
+    },
+    {
+      "ID Place": "16000US3918000",
+      Place: "Columbus, OH",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.51589565769096,
+      "Slug Place": "columbus-oh"
+    },
+    {
+      "ID Place": "16000US3916000",
+      Place: "Cleveland, OH",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.45242294987332,
+      "Slug Place": "cleveland-oh"
+    },
+    {
+      "ID Place": "16000US0446000",
+      Place: "Mesa, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.300339743066623,
+      "Slug Place": "mesa-az"
+    },
+    {
+      "ID Place": "16000US4516000",
+      Place: "Columbia, SC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 14.51283225741809,
+      "Slug Place": "columbia-sc"
+    },
+    {
+      "ID Place": "16000US3915000",
+      Place: "Cincinnati, OH",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.04342107020285,
+      "Slug Place": "cincinnati-oh"
+    },
+    {
+      "ID Place": "16000US0454050",
+      Place: "Peoria, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.0921558605919,
+      "Slug Place": "peoria-az"
+    },
+    {
+      "ID Place": "16000US3901000",
+      Place: "Akron, OH",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.609827710376155,
+      "Slug Place": "akron-oh"
+    },
+    {
+      "ID Place": "16000US3825700",
+      Place: "Fargo, ND",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 14.370928901346177,
+      "Slug Place": "fargo-nd"
+    },
+    {
+      "ID Place": "16000US3775000",
+      Place: "Winston-Salem, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.229784599697748,
+      "Slug Place": "winston-salem-nc"
+    },
+    {
+      "ID Place": "16000US0455000",
+      Place: "Phoenix, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.764471139737214,
+      "Slug Place": "phoenix-az"
+    },
+    {
+      "ID Place": "16000US4659020",
+      Place: "Sioux Falls, SD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 16.30836776859504,
+      "Slug Place": "sioux-falls-sd"
+    },
+    {
+      "ID Place": "16000US0465000",
+      Place: "Scottsdale, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.941041687774238,
+      "Slug Place": "scottsdale-az"
+    },
+    {
+      "ID Place": "16000US3755000",
+      Place: "Raleigh, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.83999686575643,
+      "Slug Place": "raleigh-nc"
+    },
+    {
+      "ID Place": "16000US3728000",
+      Place: "Greensboro, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.988357974430397,
+      "Slug Place": "greensboro-nc"
+    },
+    {
+      "ID Place": "16000US0473000",
+      Place: "Tempe, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.993014080072417,
+      "Slug Place": "tempe-az"
+    },
+    {
+      "ID Place": "16000US5553000",
+      Place: "Milwaukee, WI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.39635610025197,
+      "Slug Place": "milwaukee-wi"
+    },
+    {
+      "ID Place": "16000US3722920",
+      Place: "Fayetteville, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.97356658293942,
+      "Slug Place": "fayetteville-nc"
+    },
+    {
+      "ID Place": "16000US3719000",
+      Place: "Durham, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.164857590075922,
+      "Slug Place": "durham-nc"
+    },
+    {
+      "ID Place": "16000US0477000",
+      Place: "Tucson, AZ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.204202824642074,
+      "Slug Place": "tucson-az"
+    },
+    {
+      "ID Place": "16000US4714000",
+      Place: "Chattanooga, TN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.221641655021568,
+      "Slug Place": "chattanooga-tn"
+    },
+    {
+      "ID Place": "16000US3712000",
+      Place: "Charlotte, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.417117578641175,
+      "Slug Place": "charlotte-nc"
+    },
+    {
+      "ID Place": "16000US3710740",
+      Place: "Cary, NC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.411642868713987,
+      "Slug Place": "cary-nc"
+    },
+    {
+      "ID Place": "16000US0541000",
+      Place: "Little Rock, AR",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.259686844623623,
+      "Slug Place": "little-rock-ar"
+    },
+    {
+      "ID Place": "16000US3684000",
+      Place: "Yonkers, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.851333312637756,
+      "Slug Place": "yonkers-ny"
+    },
+    {
+      "ID Place": "16000US4715160",
+      Place: "Clarksville, TN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.25796130851511,
+      "Slug Place": "clarksville-tn"
+    },
+    {
+      "ID Place": "16000US3673000",
+      Place: "Syracuse, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 16.44790588235294,
+      "Slug Place": "syracuse-ny"
+    },
+    {
+      "ID Place": "16000US0600562",
+      Place: "Alameda, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.52852274411024,
+      "Slug Place": "alameda-ca"
+    },
+    {
+      "ID Place": "16000US3663000",
+      Place: "Rochester, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.219740499445184,
+      "Slug Place": "rochester-ny"
+    },
+    {
+      "ID Place": "16000US0600884",
+      Place: "Alhambra, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.280442366566202,
+      "Slug Place": "alhambra-ca"
+    },
+    {
+      "ID Place": "16000US5548000",
+      Place: "Madison, WI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.9021714021714,
+      "Slug Place": "madison-wi"
+    },
+    {
+      "ID Place": "16000US3651000",
+      Place: "New York, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 40.02303105927404,
+      "Slug Place": "new-york-ny"
+    },
+    {
+      "ID Place": "16000US4740000",
+      Place: "Knoxville, TN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.4733422174253,
+      "Slug Place": "knoxville-tn"
+    },
+    {
+      "ID Place": "16000US0602000",
+      Place: "Anaheim, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.540736655733898,
+      "Slug Place": "anaheim-ca"
+    },
+    {
+      "ID Place": "16000US3650617",
+      Place: "New Rochelle, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.22123441153546,
+      "Slug Place": "new-rochelle-ny"
+    },
+    {
+      "ID Place": "16000US0602252",
+      Place: "Antioch, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 44.04891083475575,
+      "Slug Place": "antioch-ca"
+    },
+    {
+      "ID Place": "16000US3649121",
+      Place: "Mount Vernon, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.71580315272049,
+      "Slug Place": "mount-vernon-ny"
+    },
+    {
+      "ID Place": "16000US3611000",
+      Place: "Buffalo, NY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.856691517019335,
+      "Slug Place": "buffalo-ny"
+    },
+    {
+      "ID Place": "16000US0602553",
+      Place: "Arden-Arcade, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.308937808810224,
+      "Slug Place": "arden-arcade-ca"
+    },
+    {
+      "ID Place": "16000US3502000",
+      Place: "Albuquerque, NM",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.882626867950457,
+      "Slug Place": "albuquerque-nm"
+    },
+    {
+      "ID Place": "16000US4748000",
+      Place: "Memphis, TN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.766794454050906,
+      "Slug Place": "memphis-tn"
+    },
+    {
+      "ID Place": "16000US3474630",
+      Place: "Union City, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.18301854783986,
+      "Slug Place": "union-city-nj"
+    },
+    {
+      "ID Place": "16000US0603526",
+      Place: "Bakersfield, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.24498553235045,
+      "Slug Place": "bakersfield-ca"
+    },
+    {
+      "ID Place": "16000US3457000",
+      Place: "Paterson, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.461508155385708,
+      "Slug Place": "paterson-nj"
+    },
+    {
+      "ID Place": "16000US0604982",
+      Place: "Bellflower, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.269152785976438,
+      "Slug Place": "bellflower-ca"
+    },
+    {
+      "ID Place": "16000US3456550",
+      Place: "Passaic, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.63514620507889,
+      "Slug Place": "passaic-nj"
+    },
+    {
+      "ID Place": "16000US4752006",
+      Place: "Nashville-Davidson metropolitan government (balance), TN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.140022970840253,
+      "Slug Place": "nashville-davidson-metropolitan-government-(balance)-tn"
+    },
+    {
+      "ID Place": "16000US0606000",
+      Place: "Berkeley, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.854698634806745,
+      "Slug Place": "berkeley-ca"
+    },
+    {
+      "ID Place": "16000US3451000",
+      Place: "Newark, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.74128730886315,
+      "Slug Place": "newark-nj"
+    },
+    {
+      "ID Place": "16000US3436000",
+      Place: "Jersey City, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 35.54695315558262,
+      "Slug Place": "jersey-city-nj"
+    },
+    {
+      "ID Place": "16000US3421000",
+      Place: "Elizabeth, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.228869365562765,
+      "Slug Place": "elizabeth-nj"
+    },
+    {
+      "ID Place": "16000US3419390",
+      Place: "East Orange, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.980020557625593,
+      "Slug Place": "east-orange-nj"
+    },
+    {
+      "ID Place": "16000US3413690",
+      Place: "Clifton, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.701284222712946,
+      "Slug Place": "clifton-nj"
+    },
+    {
+      "ID Place": "16000US3403580",
+      Place: "Bayonne, NJ",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 37.20485717064946,
+      "Slug Place": "bayonne-nj"
+    },
+    {
+      "ID Place": "16000US5531000",
+      Place: "Green Bay, WI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.206903501218374,
+      "Slug Place": "green-bay-wi"
+    },
+    {
+      "ID Place": "16000US3271400",
+      Place: "Sunrise Manor, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.487646844389044,
+      "Slug Place": "sunrise-manor-nv"
+    },
+    {
+      "ID Place": "16000US3268585",
+      Place: "Spring Valley, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.49138639778494,
+      "Slug Place": "spring-valley-nv"
+    },
+    {
+      "ID Place": "16000US0613392",
+      Place: "Chula Vista, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.77174536417511,
+      "Slug Place": "chula-vista-ca"
+    },
+    {
+      "ID Place": "16000US4804000",
+      Place: "Arlington, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.239640919792976,
+      "Slug Place": "arlington-tx"
+    },
+    {
+      "ID Place": "16000US3260600",
+      Place: "Reno, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.455441262051934,
+      "Slug Place": "reno-nv"
+    },
+    {
+      "ID Place": "16000US0615044",
+      Place: "Compton, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.66133963669998,
+      "Slug Place": "compton-ca"
+    },
+    {
+      "ID Place": "16000US3254600",
+      Place: "Paradise, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.832846328668342,
+      "Slug Place": "paradise-nv"
+    },
+    {
+      "ID Place": "16000US3251800",
+      Place: "North Las Vegas, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.848894500507893,
+      "Slug Place": "north-las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US3240000",
+      Place: "Las Vegas, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.188968538430903,
+      "Slug Place": "las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US0616000",
+      Place: "Concord, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.39266317447055,
+      "Slug Place": "concord-ca"
+    },
+    {
+      "ID Place": "16000US4805000",
+      Place: "Austin, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.709626294195193,
+      "Slug Place": "austin-tx"
+    },
+    {
+      "ID Place": "16000US3231900",
+      Place: "Henderson, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.214818158097025,
+      "Slug Place": "henderson-nv"
+    },
+    {
+      "ID Place": "16000US0616350",
+      Place: "Corona, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 35.293037638305066,
+      "Slug Place": "corona-ca"
+    },
+    {
+      "ID Place": "16000US5502375",
+      Place: "Appleton, WI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.64625113372972,
+      "Slug Place": "appleton-wi"
+    },
+    {
+      "ID Place": "16000US3223770",
+      Place: "Enterprise, NV",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.77497781721384,
+      "Slug Place": "enterprise-nv"
+    },
+    {
+      "ID Place": "16000US0616532",
+      Place: "Costa Mesa, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.14674187839717,
+      "Slug Place": "costa-mesa-ca"
+    },
+    {
+      "ID Place": "16000US5374060",
+      Place: "Vancouver, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.550107161333234,
+      "Slug Place": "vancouver-wa"
+    },
+    {
+      "ID Place": "16000US3137000",
+      Place: "Omaha, NE",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.582624749185882,
+      "Slug Place": "omaha-ne"
+    },
+    {
+      "ID Place": "16000US3128000",
+      Place: "Lincoln, NE",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.35028865453642,
+      "Slug Place": "lincoln-ne"
+    },
+    {
+      "ID Place": "16000US0617918",
+      Place: "Daly City, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.05803602475833,
+      "Slug Place": "daly-city-ca"
+    },
+    {
+      "ID Place": "16000US3050200",
+      Place: "Missoula, MT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 14.049135354920884,
+      "Slug Place": "missoula-mt"
+    },
+    {
+      "ID Place": "16000US0618100",
+      Place: "Davis, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.709514807813484,
+      "Slug Place": "davis-ca"
+    },
+    {
+      "ID Place": "16000US4810768",
+      Place: "Brownsville, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.648291488403512,
+      "Slug Place": "brownsville-tx"
+    },
+    {
+      "ID Place": "16000US2970000",
+      Place: "Springfield, MO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.000351026753254,
+      "Slug Place": "springfield-mo"
+    },
+    {
+      "ID Place": "16000US0619766",
+      Place: "Downey, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.145742873324522,
+      "Slug Place": "downey-ca"
+    },
+    {
+      "ID Place": "16000US2965000",
+      Place: "St. Louis, MO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.541931170567693,
+      "Slug Place": "st.-louis-mo"
+    },
+    {
+      "ID Place": "16000US4813024",
+      Place: "Carrollton, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.530094474129545,
+      "Slug Place": "carrollton-tx"
+    },
+    {
+      "ID Place": "16000US0620802",
+      Place: "East Los Angeles, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.417533432392272,
+      "Slug Place": "east-los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US2938000",
+      Place: "Kansas City, MO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.033086955303798,
+      "Slug Place": "kansas-city-mo"
+    },
+    {
+      "ID Place": "16000US0621712",
+      Place: "El Cajon, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.795237463518173,
+      "Slug Place": "el-cajon-ca"
+    },
+    {
+      "ID Place": "16000US2915670",
+      Place: "Columbia, MO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.85831338039118,
+      "Slug Place": "columbia-mo"
+    },
+    {
+      "ID Place": "16000US4815976",
+      Place: "College Station, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.433604076472166,
+      "Slug Place": "college-station-tx"
+    },
+    {
+      "ID Place": "16000US2758000",
+      Place: "St. Paul, MN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.3702910542198,
+      "Slug Place": "st.-paul-mn"
+    },
+    {
+      "ID Place": "16000US0622020",
+      Place: "Elk Grove, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.771600114125512,
+      "Slug Place": "elk-grove-ca"
+    },
+    {
+      "ID Place": "16000US2754880",
+      Place: "Rochester, MN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.363046286153393,
+      "Slug Place": "rochester-mn"
+    },
+    {
+      "ID Place": "16000US5370000",
+      Place: "Tacoma, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.20015070262653,
+      "Slug Place": "tacoma-wa"
+    },
+    {
+      "ID Place": "16000US2743000",
+      Place: "Minneapolis, MN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.02456876610931,
+      "Slug Place": "minneapolis-mn"
+    },
+    {
+      "ID Place": "16000US2717288",
+      Place: "Eagan, MN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.20777986037541,
+      "Slug Place": "eagan-mn"
+    },
+    {
+      "ID Place": "16000US0622804",
+      Place: "Escondido, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.31705528669893,
+      "Slug Place": "escondido-ca"
+    },
+    {
+      "ID Place": "16000US2717000",
+      Place: "Duluth, MN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.64844401379093,
+      "Slug Place": "duluth-mn"
+    },
+    {
+      "ID Place": "16000US4817000",
+      Place: "Corpus Christi, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.515167821349298,
+      "Slug Place": "corpus-christi-tx"
+    },
+    {
+      "ID Place": "16000US0623182",
+      Place: "Fairfield, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.790867308014366,
+      "Slug Place": "fairfield-ca"
+    },
+    {
+      "ID Place": "16000US2684000",
+      Place: "Warren, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.614644819865664,
+      "Slug Place": "warren-mi"
+    },
+    {
+      "ID Place": "16000US2634000",
+      Place: "Grand Rapids, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.01449233130324,
+      "Slug Place": "grand-rapids-mi"
+    },
+    {
+      "ID Place": "16000US2629000",
+      Place: "Flint, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.969430163470122,
+      "Slug Place": "flint-mi"
+    },
+    {
+      "ID Place": "16000US2622000",
+      Place: "Detroit, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.34812162859216,
+      "Slug Place": "detroit-mi"
+    },
+    {
+      "ID Place": "16000US0624680",
+      Place: "Fontana, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.264960638099,
+      "Slug Place": "fontana-ca"
+    },
+    {
+      "ID Place": "16000US4819000",
+      Place: "Dallas, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.640222305840755,
+      "Slug Place": "dallas-tx"
+    },
+    {
+      "ID Place": "16000US2621000",
+      Place: "Dearborn, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.37748930520726,
+      "Slug Place": "dearborn-mi"
+    },
+    {
+      "ID Place": "16000US0626000",
+      Place: "Fremont, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.685213147626925,
+      "Slug Place": "fremont-ca"
+    },
+    {
+      "ID Place": "16000US5367000",
+      Place: "Spokane, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.071693859269473,
+      "Slug Place": "spokane-wa"
+    },
+    {
+      "ID Place": "16000US2603000",
+      Place: "Ann Arbor, MI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.418478007188313,
+      "Slug Place": "ann-arbor-mi"
+    },
+    {
+      "ID Place": "16000US2582000",
+      Place: "Worcester, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.70843684785849,
+      "Slug Place": "worcester-ma"
+    },
+    {
+      "ID Place": "16000US0627000",
+      Place: "Fresno, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.683186776360195,
+      "Slug Place": "fresno-ca"
+    },
+    {
+      "ID Place": "16000US2562535",
+      Place: "Somerville, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.743212669683256,
+      "Slug Place": "somerville-ma"
+    },
+    {
+      "ID Place": "16000US4819972",
+      Place: "Denton, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.79072988656577,
+      "Slug Place": "denton-tx"
+    },
+    {
+      "ID Place": "16000US2555745",
+      Place: "Quincy, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.52649140918811,
+      "Slug Place": "quincy-ma"
+    },
+    {
+      "ID Place": "16000US0628000",
+      Place: "Fullerton, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.933746721448173,
+      "Slug Place": "fullerton-ca"
+    },
+    {
+      "ID Place": "16000US2545560",
+      Place: "Newton, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.43378517106283,
+      "Slug Place": "newton-ma"
+    },
+    {
+      "ID Place": "16000US2545000",
+      Place: "New Bedford, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.725685841201813,
+      "Slug Place": "new-bedford-ma"
+    },
+    {
+      "ID Place": "16000US2537490",
+      Place: "Lynn, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.839387464387464,
+      "Slug Place": "lynn-ma"
+    },
+    {
+      "ID Place": "16000US0629000",
+      Place: "Garden Grove, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.543250342887696,
+      "Slug Place": "garden-grove-ca"
+    },
+    {
+      "ID Place": "16000US2537000",
+      Place: "Lowell, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.882859169653525,
+      "Slug Place": "lowell-ma"
+    },
+    {
+      "ID Place": "16000US4824000",
+      Place: "El Paso, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.432553427110577,
+      "Slug Place": "el-paso-tx"
+    },
+    {
+      "ID Place": "16000US0630000",
+      Place: "Glendale, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.25011799997902,
+      "Slug Place": "glendale-ca"
+    },
+    {
+      "ID Place": "16000US5363000",
+      Place: "Seattle, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.23188456735016,
+      "Slug Place": "seattle-wa"
+    },
+    {
+      "ID Place": "16000US0632548",
+      Place: "Hawthorne, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.50686046511628,
+      "Slug Place": "hawthorne-ca"
+    },
+    {
+      "ID Place": "16000US2534550",
+      Place: "Lawrence, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.943817302190084,
+      "Slug Place": "lawrence-ma"
+    },
+    {
+      "ID Place": "16000US2511000",
+      Place: "Cambridge, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.68063280187863,
+      "Slug Place": "cambridge-ma"
+    },
+    {
+      "ID Place": "16000US2509000",
+      Place: "Brockton, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.050489126913856,
+      "Slug Place": "brockton-ma"
+    },
+    {
+      "ID Place": "16000US0633000",
+      Place: "Hayward, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.51501176619233,
+      "Slug Place": "hayward-ca"
+    },
+    {
+      "ID Place": "16000US4827000",
+      Place: "Fort Worth, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.02850288928542,
+      "Slug Place": "fort-worth-tx"
+    },
+    {
+      "ID Place": "16000US2507000",
+      Place: "Boston, MA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.85679650880879,
+      "Slug Place": "boston-ma"
+    },
+    {
+      "ID Place": "16000US2472450",
+      Place: "Silver Spring, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.91082484304738,
+      "Slug Place": "silver-spring-md"
+    },
+    {
+      "ID Place": "16000US0636000",
+      Place: "Huntington Beach, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.425284936409657,
+      "Slug Place": "huntington-beach-ca"
+    },
+    {
+      "ID Place": "16000US2467675",
+      Place: "Rockville, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.28277374725831,
+      "Slug Place": "rockville-md"
+    },
+    {
+      "ID Place": "16000US2432025",
+      Place: "Germantown, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.762855078103286,
+      "Slug Place": "germantown-md"
+    },
+    {
+      "ID Place": "16000US0636546",
+      Place: "Inglewood, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.33732270380408,
+      "Slug Place": "inglewood-ca"
+    },
+    {
+      "ID Place": "16000US2431175",
+      Place: "Gaithersburg, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.89547558608332,
+      "Slug Place": "gaithersburg-md"
+    },
+    {
+      "ID Place": "16000US2430325",
+      Place: "Frederick, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 35.686499731985606,
+      "Slug Place": "frederick-md"
+    },
+    {
+      "ID Place": "16000US4829000",
+      Place: "Garland, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.98609249905508,
+      "Slug Place": "garland-tx"
+    },
+    {
+      "ID Place": "16000US0636770",
+      Place: "Irvine, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.82759944708954,
+      "Slug Place": "irvine-ca"
+    },
+    {
+      "ID Place": "16000US0639892",
+      Place: "Lakewood, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.829806568869273,
+      "Slug Place": "lakewood-ca"
+    },
+    {
+      "ID Place": "16000US2407125",
+      Place: "Bethesda, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.18110918544194,
+      "Slug Place": "bethesda-md"
+    },
+    {
+      "ID Place": "16000US2404000",
+      Place: "Baltimore, MD",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.25988904099719,
+      "Slug Place": "baltimore-md"
+    },
+    {
+      "ID Place": "16000US0640130",
+      Place: "Lancaster, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.550584741043252,
+      "Slug Place": "lancaster-ca"
+    },
+    {
+      "ID Place": "16000US2270000",
+      Place: "Shreveport, LA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.0538796375968,
+      "Slug Place": "shreveport-la"
+    },
+    {
+      "ID Place": "16000US2255000",
+      Place: "New Orleans, LA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.782237889470093,
+      "Slug Place": "new-orleans-la"
+    },
+    {
+      "ID Place": "16000US4835000",
+      Place: "Houston, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.542911334573194,
+      "Slug Place": "houston-tx"
+    },
+    {
+      "ID Place": "16000US2205000",
+      Place: "Baton Rouge, LA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.440743556751276,
+      "Slug Place": "baton-rouge-la"
+    },
+    {
+      "ID Place": "16000US0643000",
+      Place: "Long Beach, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.505201304419007,
+      "Slug Place": "long-beach-ca"
+    },
+    {
+      "ID Place": "16000US2148006",
+      Place: "Louisville/Jefferson County metro government (balance), KY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.67521537113283,
+      "Slug Place": "louisville-jefferson-county-metro-government-(balance)-ky"
+    },
+    {
+      "ID Place": "16000US2146027",
+      Place: "Lexington-Fayette, KY",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.836608363924277,
+      "Slug Place": "lexington-fayette-ky"
+    },
+    {
+      "ID Place": "16000US4837000",
+      Place: "Irving, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.540929256690745,
+      "Slug Place": "irving-tx"
+    },
+    {
+      "ID Place": "16000US0644000",
+      Place: "Los Angeles, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.808278405634447,
+      "Slug Place": "los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US2079000",
+      Place: "Wichita, KS",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.380190389105692,
+      "Slug Place": "wichita-ks"
+    },
+    {
+      "ID Place": "16000US2071000",
+      Place: "Topeka, KS",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.709723570589137,
+      "Slug Place": "topeka-ks"
+    },
+    {
+      "ID Place": "16000US5335415",
+      Place: "Kent, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.64740841626298,
+      "Slug Place": "kent-wa"
+    },
+    {
+      "ID Place": "16000US2038900",
+      Place: "Lawrence, KS",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.23111136563204,
+      "Slug Place": "lawrence-ks"
+    },
+    {
+      "ID Place": "16000US1938595",
+      Place: "Iowa City, IA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.519847364884324,
+      "Slug Place": "iowa-city-ia"
+    },
+    {
+      "ID Place": "16000US1921000",
+      Place: "Des Moines, IA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.09974285255094,
+      "Slug Place": "des-moines-ia"
+    },
+    {
+      "ID Place": "16000US4841464",
+      Place: "Laredo, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.352191849995712,
+      "Slug Place": "laredo-tx"
+    },
+    {
+      "ID Place": "16000US1871000",
+      Place: "South Bend, IN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.940467097192325,
+      "Slug Place": "south-bend-in"
+    },
+    {
+      "ID Place": "16000US0649270",
+      Place: "Moreno Valley, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.907401455497144,
+      "Slug Place": "moreno-valley-ca"
+    },
+    {
+      "ID Place": "16000US1836003",
+      Place: "Indianapolis city (balance), IN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.531093662722487,
+      "Slug Place": "indianapolis-city-(balance)-in"
+    },
+    {
+      "ID Place": "16000US1825000",
+      Place: "Fort Wayne, IN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.671761700725117,
+      "Slug Place": "fort-wayne-in"
+    },
+    {
+      "ID Place": "16000US1822000",
+      Place: "Evansville, IN",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.033011737921512,
+      "Slug Place": "evansville-in"
+    },
+    {
+      "ID Place": "16000US0649670",
+      Place: "Mountain View, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.761238590804403,
+      "Slug Place": "mountain-view-ca"
+    },
+    {
+      "ID Place": "16000US4845000",
+      Place: "Lubbock, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.787302725968436,
+      "Slug Place": "lubbock-tx"
+    },
+    {
+      "ID Place": "16000US1779293",
+      Place: "Waukegan, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.012822620417555,
+      "Slug Place": "waukegan-il"
+    },
+    {
+      "ID Place": "16000US0650258",
+      Place: "Napa, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.723549900827244,
+      "Slug Place": "napa-ca"
+    },
+    {
+      "ID Place": "16000US1772000",
+      Place: "Springfield, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.256176565266376,
+      "Slug Place": "springfield-il"
+    },
+    {
+      "ID Place": "16000US1770122",
+      Place: "Skokie, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.508250251849795,
+      "Slug Place": "skokie-il"
+    },
+    {
+      "ID Place": "16000US1765000",
+      Place: "Rockford, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.34641239340351,
+      "Slug Place": "rockford-il"
+    },
+    {
+      "ID Place": "16000US1751622",
+      Place: "Naperville, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.565059445178335,
+      "Slug Place": "naperville-il"
+    },
+    {
+      "ID Place": "16000US0653000",
+      Place: "Oakland, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.72167088723108,
+      "Slug Place": "oakland-ca"
+    },
+    {
+      "ID Place": "16000US1738570",
+      Place: "Joliet, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.35213104849783,
+      "Slug Place": "joliet-il"
+    },
+    {
+      "ID Place": "16000US1724582",
+      Place: "Evanston, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.018048737470238,
+      "Slug Place": "evanston-il"
+    },
+    {
+      "ID Place": "16000US4858016",
+      Place: "Plano, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.05314235866121,
+      "Slug Place": "plano-tx"
+    },
+    {
+      "ID Place": "16000US0653322",
+      Place: "Oceanside, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.634578958445385,
+      "Slug Place": "oceanside-ca"
+    },
+    {
+      "ID Place": "16000US1723074",
+      Place: "Elgin, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.157458613624414,
+      "Slug Place": "elgin-il"
+    },
+    {
+      "ID Place": "16000US1714351",
+      Place: "Cicero, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.958693941778126,
+      "Slug Place": "cicero-il"
+    },
+    {
+      "ID Place": "16000US0653896",
+      Place: "Ontario, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.35341474223251,
+      "Slug Place": "ontario-ca"
+    },
+    {
+      "ID Place": "16000US1714000",
+      Place: "Chicago, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.105186815799314,
+      "Slug Place": "chicago-il"
+    },
+    {
+      "ID Place": "16000US1712385",
+      Place: "Champaign, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 14.683164370936808,
+      "Slug Place": "champaign-il"
+    },
+    {
+      "ID Place": "16000US1703012",
+      Place: "Aurora, IL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.480065947242206,
+      "Slug Place": "aurora-il"
+    },
+    {
+      "ID Place": "16000US1608830",
+      Place: "Boise City, ID",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.936057148559645,
+      "Slug Place": "boise-city-id"
+    },
+    {
+      "ID Place": "16000US1571550",
+      Place: "Urban Honolulu, HI",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.269247325889964,
+      "Slug Place": "urban-honolulu-hi"
+    },
+    {
+      "ID Place": "16000US0654652",
+      Place: "Oxnard, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.30812923344842,
+      "Slug Place": "oxnard-ca"
+    },
+    {
+      "ID Place": "16000US4865000",
+      Place: "San Antonio, TX",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.579411179912515,
+      "Slug Place": "san-antonio-tx"
+    },
+    {
+      "ID Place": "16000US1369000",
+      Place: "Savannah, GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.319020628270735,
+      "Slug Place": "savannah-ga"
+    },
+    {
+      "ID Place": "16000US1368516",
+      Place: "Sandy Springs, GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.96581356832599,
+      "Slug Place": "sandy-springs-ga"
+    },
+    {
+      "ID Place": "16000US0655156",
+      Place: "Palmdale, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 40.8622761297027,
+      "Slug Place": "palmdale-ca"
+    },
+    {
+      "ID Place": "16000US1349008",
+      Place: "Macon-Bibb County, GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.225098296199214,
+      "Slug Place": "macon-bibb-county-ga"
+    },
+    {
+      "ID Place": "16000US1319000",
+      Place: "Columbus, GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.35441838127496,
+      "Slug Place": "columbus-ga"
+    },
+    {
+      "ID Place": "16000US0655282",
+      Place: "Palo Alto, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.78826128116125,
+      "Slug Place": "palo-alto-ca"
+    },
+    {
+      "ID Place": "16000US1304204",
+      Place: "Augusta-Richmond County consolidated government (balance), GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.89343012261331,
+      "Slug Place":
+        "augusta-richmond-county-consolidated-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US1304000",
+      Place: "Atlanta, GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.82727043904544,
+      "Slug Place": "atlanta-ga"
+    },
+    {
+      "ID Place": "16000US0656000",
+      Place: "Pasadena, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.721128197081438,
+      "Slug Place": "pasadena-ca"
+    },
+    {
+      "ID Place": "16000US1303440",
+      Place: "Athens-Clarke County unified government (balance), GA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 16.961091646690026,
+      "Slug Place": "athens-clarke-county-unified-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US0657456",
+      Place: "Pittsburg, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 41.896474387727636,
+      "Slug Place": "pittsburg-ca"
+    },
+    {
+      "ID Place": "16000US1276600",
+      Place: "West Palm Beach, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.589622102979792,
+      "Slug Place": "west-palm-beach-fl"
+    },
+    {
+      "ID Place": "16000US1271000",
+      Place: "Tampa, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.820516879306886,
+      "Slug Place": "tampa-fl"
+    },
+    {
+      "ID Place": "16000US0657792",
+      Place: "Pleasanton, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 32.59649316277018,
+      "Slug Place": "pleasanton-ca"
+    },
+    {
+      "ID Place": "16000US5305210",
+      Place: "Bellevue, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.39116296085525,
+      "Slug Place": "bellevue-wa"
+    },
+    {
+      "ID Place": "16000US1263000",
+      Place: "St. Petersburg, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.160006372035866,
+      "Slug Place": "st.-petersburg-fl"
+    },
+    {
+      "ID Place": "16000US4957300",
+      Place: "Orem, UT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.225015846186352,
+      "Slug Place": "orem-ut"
+    },
+    {
+      "ID Place": "16000US0658072",
+      Place: "Pomona, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.192765846448136,
+      "Slug Place": "pomona-ca"
+    },
+    {
+      "ID Place": "16000US1253000",
+      Place: "Orlando, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.59301622290023,
+      "Slug Place": "orlando-fl"
+    },
+    {
+      "ID Place": "16000US1245025",
+      Place: "Miami Beach, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.009793732011513,
+      "Slug Place": "miami-beach-fl"
+    },
+    {
+      "ID Place": "16000US1245000",
+      Place: "Miami, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.88535371569855,
+      "Slug Place": "miami-fl"
+    },
+    {
+      "ID Place": "16000US1235000",
+      Place: "Jacksonville, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.01657354003522,
+      "Slug Place": "jacksonville-fl"
+    },
+    {
+      "ID Place": "16000US0659451",
+      Place: "Rancho Cucamonga, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.683210100446427,
+      "Slug Place": "rancho-cucamonga-ca"
+    },
+    {
+      "ID Place": "16000US4962470",
+      Place: "Provo, UT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.52547729618163,
+      "Slug Place": "provo-ut"
+    },
+    {
+      "ID Place": "16000US1232000",
+      Place: "Hollywood, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.580797957054205,
+      "Slug Place": "hollywood-fl"
+    },
+    {
+      "ID Place": "16000US1230000",
+      Place: "Hialeah, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.22894806454457,
+      "Slug Place": "hialeah-fl"
+    },
+    {
+      "ID Place": "16000US0660102",
+      Place: "Redwood City, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.626596407956395,
+      "Slug Place": "redwood-city-ca"
+    },
+    {
+      "ID Place": "16000US1225175",
+      Place: "Gainesville, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.44486044406254,
+      "Slug Place": "gainesville-fl"
+    },
+    {
+      "ID Place": "16000US5303180",
+      Place: "Auburn, WA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.667464907140854,
+      "Slug Place": "auburn-wa"
+    },
+    {
+      "ID Place": "16000US1224000",
+      Place: "Fort Lauderdale, FL",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.804660256336966,
+      "Slug Place": "fort-lauderdale-fl"
+    },
+    {
+      "ID Place": "16000US4967000",
+      Place: "Salt Lake City, UT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.885720269150575,
+      "Slug Place": "salt-lake-city-ut"
+    },
+    {
+      "ID Place": "16000US0660620",
+      Place: "Richmond, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.41788825953595,
+      "Slug Place": "richmond-ca"
+    },
+    {
+      "ID Place": "16000US1150000",
+      Place: "Washington, DC",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.56758484735468,
+      "Slug Place": "washington-dc"
+    },
+    {
+      "ID Place": "16000US0973000",
+      Place: "Stamford, CT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.316115820012516,
+      "Slug Place": "stamford-ct"
+    },
+    {
+      "ID Place": "16000US0955990",
+      Place: "Norwalk, CT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.464799442367404,
+      "Slug Place": "norwalk-ct"
+    },
+    {
+      "ID Place": "16000US0662000",
+      Place: "Riverside, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.8261899993324,
+      "Slug Place": "riverside-ca"
+    },
+    {
+      "ID Place": "16000US0952000",
+      Place: "New Haven, CT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.017188993581865,
+      "Slug Place": "new-haven-ct"
+    },
+    {
+      "ID Place": "16000US5182000",
+      Place: "Virginia Beach, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.31231741714516,
+      "Slug Place": "virginia-beach-va"
+    },
+    {
+      "ID Place": "16000US4983470",
+      Place: "West Valley City, UT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.583390886411365,
+      "Slug Place": "west-valley-city-ut"
+    },
+    {
+      "ID Place": "16000US0908000",
+      Place: "Bridgeport, CT",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.605289649492082,
+      "Slug Place": "bridgeport-ct"
+    },
+    {
+      "ID Place": "16000US0664000",
+      Place: "Sacramento, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.816455946353052,
+      "Slug Place": "sacramento-ca"
+    },
+    {
+      "ID Place": "16000US0883835",
+      Place: "Westminster, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.651574031741884,
+      "Slug Place": "westminster-co"
+    },
+    {
+      "ID Place": "16000US5101000",
+      Place: "Alexandria, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.8976600874341,
+      "Slug Place": "alexandria-va"
+    },
+    {
+      "ID Place": "16000US0843000",
+      Place: "Lakewood, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.317008162585374,
+      "Slug Place": "lakewood-co"
+    },
+    {
+      "ID Place": "16000US0664224",
+      Place: "Salinas, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.415765270708004,
+      "Slug Place": "salinas-ca"
+    },
+    {
+      "ID Place": "16000US0836410",
+      Place: "Highlands Ranch, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.85047208175678,
+      "Slug Place": "highlands-ranch-co"
+    },
+    {
+      "ID Place": "16000US0827425",
+      Place: "Fort Collins, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 18.742955214880443,
+      "Slug Place": "fort-collins-co"
+    },
+    {
+      "ID Place": "16000US5103000",
+      Place: "Arlington, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.96924236059715,
+      "Slug Place": "arlington-va"
+    },
+    {
+      "ID Place": "16000US0665000",
+      Place: "San Bernardino, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.984630357571696,
+      "Slug Place": "san-bernardino-ca"
+    },
+    {
+      "ID Place": "16000US0820000",
+      Place: "Denver, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.497603298468388,
+      "Slug Place": "denver-co"
+    },
+    {
+      "ID Place": "16000US0816000",
+      Place: "Colorado Springs, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 21.492339121552604,
+      "Slug Place": "colorado-springs-co"
+    },
+    {
+      "ID Place": "16000US0665042",
+      Place: "San Buenaventura (Ventura), CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.411488639181943,
+      "Slug Place": "san-buenaventura-(ventura)-ca"
+    },
+    {
+      "ID Place": "16000US5114440",
+      Place: "Centreville, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.30093518820081,
+      "Slug Place": "centreville-va"
+    },
+    {
+      "ID Place": "16000US0812815",
+      Place: "Centennial, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.09074903422105,
+      "Slug Place": "centennial-co"
+    },
+    {
+      "ID Place": "16000US0666000",
+      Place: "San Diego, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.899272306873648,
+      "Slug Place": "san-diego-ca"
+    },
+    {
+      "ID Place": "16000US5167000",
+      Place: "Richmond, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.757443692285708,
+      "Slug Place": "richmond-va"
+    },
+    {
+      "ID Place": "16000US0807850",
+      Place: "Boulder, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 17.41560055303733,
+      "Slug Place": "boulder-co"
+    },
+    {
+      "ID Place": "16000US0804000",
+      Place: "Aurora, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.8519379081069,
+      "Slug Place": "aurora-co"
+    },
+    {
+      "ID Place": "16000US0667000",
+      Place: "San Francisco, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.422251052804548,
+      "Slug Place": "san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US0803455",
+      Place: "Arvada, CO",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.72783873751695,
+      "Slug Place": "arvada-co"
+    },
+    {
+      "ID Place": "16000US0682954",
+      Place: "Visalia, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.313394327228284,
+      "Slug Place": "visalia-ca"
+    },
+    {
+      "ID Place": "16000US5121088",
+      Place: "Dale City, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 39.56725741258939,
+      "Slug Place": "dale-city-va"
+    },
+    {
+      "ID Place": "16000US0668000",
+      Place: "San Jose, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 29.988260361199313,
+      "Slug Place": "san-jose-ca"
+    },
+    {
+      "ID Place": "16000US0681666",
+      Place: "Vallejo, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 34.755479838930086,
+      "Slug Place": "vallejo-ca"
+    },
+    {
+      "ID Place": "16000US5135000",
+      Place: "Hampton, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.761044021461817,
+      "Slug Place": "hampton-va"
+    },
+    {
+      "ID Place": "16000US0668084",
+      Place: "San Leandro, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 31.24829898911353,
+      "Slug Place": "san-leandro-ca"
+    },
+    {
+      "ID Place": "16000US0680000",
+      Place: "Torrance, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 26.341529976156963,
+      "Slug Place": "torrance-ca"
+    },
+    {
+      "ID Place": "16000US5147672",
+      Place: "Lynchburg, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 16.629632746962937,
+      "Slug Place": "lynchburg-va"
+    },
+    {
+      "ID Place": "16000US0677000",
+      Place: "Sunnyvale, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.535435719803633,
+      "Slug Place": "sunnyvale-ca"
+    },
+    {
+      "ID Place": "16000US0668252",
+      Place: "San Mateo, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 27.73311985866505,
+      "Slug Place": "san-mateo-ca"
+    },
+    {
+      "ID Place": "16000US0675000",
+      Place: "Stockton, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.413886240864315,
+      "Slug Place": "stockton-ca"
+    },
+    {
+      "ID Place": "16000US0668378",
+      Place: "San Ramon, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 38.097717584848645,
+      "Slug Place": "san-ramon-ca"
+    },
+    {
+      "ID Place": "16000US0673262",
+      Place: "South San Francisco, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 28.10025366714459,
+      "Slug Place": "south-san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US0673080",
+      Place: "South Gate, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 30.669793398242696,
+      "Slug Place": "south-gate-ca"
+    },
+    {
+      "ID Place": "16000US5156000",
+      Place: "Newport News, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.178632273408112,
+      "Slug Place": "newport-news-va"
+    },
+    {
+      "ID Place": "16000US0669000",
+      Place: "Santa Ana, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 25.540758724260538,
+      "Slug Place": "santa-ana-ca"
+    },
+    {
+      "ID Place": "16000US0670098",
+      Place: "Santa Rosa, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.590667714435394,
+      "Slug Place": "santa-rosa-ca"
+    },
+    {
+      "ID Place": "16000US0670000",
+      Place: "Santa Monica, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 24.33524225444957,
+      "Slug Place": "santa-monica-ca"
+    },
+    {
+      "ID Place": "16000US0669070",
+      Place: "Santa Barbara, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 15.718574823576365,
+      "Slug Place": "santa-barbara-ca"
+    },
+    {
+      "ID Place": "16000US5157000",
+      Place: "Norfolk, VA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 20.07519169499535,
+      "Slug Place": "norfolk-va"
+    },
+    {
+      "ID Place": "16000US0669196",
+      Place: "Santa Maria, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 19.853687327852217,
+      "Slug Place": "santa-maria-ca"
+    },
+    {
+      "ID Place": "16000US0669112",
+      Place: "Santa Cruz, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 23.84937301253975,
+      "Slug Place": "santa-cruz-ca"
+    },
+    {
+      "ID Place": "16000US0669084",
+      Place: "Santa Clara, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 22.90735745669839,
+      "Slug Place": "santa-clara-ca"
+    },
+    {
+      "ID Place": "16000US0669088",
+      Place: "Santa Clarita, CA",
+      "ID Year": 2017,
+      Year: "2017",
+      "Average Commute Time": 33.941563617981025,
+      "Slug Place": "santa-clarita-ca"
+    },
+    {
+      "ID Place": "16000US5357745",
+      Place: "Renton, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.4162709600831,
+      "Slug Place": "renton-wa"
+    },
+    {
+      "ID Place": "16000US2432025",
+      Place: "Germantown, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.744929367878186,
+      "Slug Place": "germantown-md"
+    },
+    {
+      "ID Place": "16000US0669084",
+      Place: "Santa Clara, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.665450286839334,
+      "Slug Place": "santa-clara-ca"
+    },
+    {
+      "ID Place": "16000US0669196",
+      Place: "Santa Maria, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.951814516129033,
+      "Slug Place": "santa-maria-ca"
+    },
+    {
+      "ID Place": "16000US0670000",
+      Place: "Santa Monica, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.9682279092226,
+      "Slug Place": "santa-monica-ca"
+    },
+    {
+      "ID Place": "16000US0669070",
+      Place: "Santa Barbara, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 14.414356487825446,
+      "Slug Place": "santa-barbara-ca"
+    },
+    {
+      "ID Place": "16000US0670098",
+      Place: "Santa Rosa, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.377578031488813,
+      "Slug Place": "santa-rosa-ca"
+    },
+    {
+      "ID Place": "16000US0669000",
+      Place: "Santa Ana, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.888346768930518,
+      "Slug Place": "santa-ana-ca"
+    },
+    {
+      "ID Place": "16000US0673080",
+      Place: "South Gate, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 32.64303059737737,
+      "Slug Place": "south-gate-ca"
+    },
+    {
+      "ID Place": "16000US5156000",
+      Place: "Newport News, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.378413280060045,
+      "Slug Place": "newport-news-va"
+    },
+    {
+      "ID Place": "16000US5164000",
+      Place: "Portsmouth, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.994068776030876,
+      "Slug Place": "portsmouth-va"
+    },
+    {
+      "ID Place": "16000US0675000",
+      Place: "Stockton, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.23895925762861,
+      "Slug Place": "stockton-ca"
+    },
+    {
+      "ID Place": "16000US0668378",
+      Place: "San Ramon, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.17604705405131,
+      "Slug Place": "san-ramon-ca"
+    },
+    {
+      "ID Place": "16000US0677000",
+      Place: "Sunnyvale, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.950288049387037,
+      "Slug Place": "sunnyvale-ca"
+    },
+    {
+      "ID Place": "16000US0668252",
+      Place: "San Mateo, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.249870120874174,
+      "Slug Place": "san-mateo-ca"
+    },
+    {
+      "ID Place": "16000US0680000",
+      Place: "Torrance, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.42301984279668,
+      "Slug Place": "torrance-ca"
+    },
+    {
+      "ID Place": "16000US0668196",
+      Place: "San Marcos, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.314510200330822,
+      "Slug Place": "san-marcos-ca"
+    },
+    {
+      "ID Place": "16000US0680854",
+      Place: "Tustin, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.677425857898037,
+      "Slug Place": "tustin-ca"
+    },
+    {
+      "ID Place": "16000US5135000",
+      Place: "Hampton, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.963079972743603,
+      "Slug Place": "hampton-va"
+    },
+    {
+      "ID Place": "16000US0681204",
+      Place: "Union City, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.137936884967765,
+      "Slug Place": "union-city-ca"
+    },
+    {
+      "ID Place": "16000US0681666",
+      Place: "Vallejo, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.68949000752418,
+      "Slug Place": "vallejo-ca"
+    },
+    {
+      "ID Place": "16000US0668000",
+      Place: "San Jose, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.34815911959763,
+      "Slug Place": "san-jose-ca"
+    },
+    {
+      "ID Place": "16000US0683346",
+      Place: "Walnut Creek, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.73627848796412,
+      "Slug Place": "walnut-creek-ca"
+    },
+    {
+      "ID Place": "16000US5121088",
+      Place: "Dale City, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 35.95047369637218,
+      "Slug Place": "dale-city-va"
+    },
+    {
+      "ID Place": "16000US0684200",
+      Place: "West Covina, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.176525990942245,
+      "Slug Place": "west-covina-ca"
+    },
+    {
+      "ID Place": "16000US0685292",
+      Place: "Whittier, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.672556146643238,
+      "Slug Place": "whittier-ca"
+    },
+    {
+      "ID Place": "16000US0803455",
+      Place: "Arvada, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.368931412252536,
+      "Slug Place": "arvada-co"
+    },
+    {
+      "ID Place": "16000US5167000",
+      Place: "Richmond, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.74960012939633,
+      "Slug Place": "richmond-va"
+    },
+    {
+      "ID Place": "16000US0804000",
+      Place: "Aurora, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.63776549781841,
+      "Slug Place": "aurora-co"
+    },
+    {
+      "ID Place": "16000US0667000",
+      Place: "San Francisco, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.387178826260968,
+      "Slug Place": "san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US5116000",
+      Place: "Chesapeake, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.628659082193533,
+      "Slug Place": "chesapeake-va"
+    },
+    {
+      "ID Place": "16000US0807850",
+      Place: "Boulder, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 16.208702590743947,
+      "Slug Place": "boulder-co"
+    },
+    {
+      "ID Place": "16000US0812815",
+      Place: "Centennial, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.443847072879333,
+      "Slug Place": "centennial-co"
+    },
+    {
+      "ID Place": "16000US0666000",
+      Place: "San Diego, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.196966733265338,
+      "Slug Place": "san-diego-ca"
+    },
+    {
+      "ID Place": "16000US0816000",
+      Place: "Colorado Springs, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.18131095685792,
+      "Slug Place": "colorado-springs-co"
+    },
+    {
+      "ID Place": "16000US0665042",
+      Place: "San Buenaventura (Ventura), CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.99934326167159,
+      "Slug Place": "san-buenaventura-(ventura)-ca"
+    },
+    {
+      "ID Place": "16000US5114440",
+      Place: "Centreville, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.81514769551159,
+      "Slug Place": "centreville-va"
+    },
+    {
+      "ID Place": "16000US0820000",
+      Place: "Denver, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.30292619043832,
+      "Slug Place": "denver-co"
+    },
+    {
+      "ID Place": "16000US0665000",
+      Place: "San Bernardino, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.471380557111576,
+      "Slug Place": "san-bernardino-ca"
+    },
+    {
+      "ID Place": "16000US0827425",
+      Place: "Fort Collins, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.432919386806713,
+      "Slug Place": "fort-collins-co"
+    },
+    {
+      "ID Place": "16000US5103000",
+      Place: "Arlington, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.945950200539336,
+      "Slug Place": "arlington-va"
+    },
+    {
+      "ID Place": "16000US0832155",
+      Place: "Greeley, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.37488155741235,
+      "Slug Place": "greeley-co"
+    },
+    {
+      "ID Place": "16000US0836410",
+      Place: "Highlands Ranch, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.437791932059447,
+      "Slug Place": "highlands-ranch-co"
+    },
+    {
+      "ID Place": "16000US0843000",
+      Place: "Lakewood, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.826167442971457,
+      "Slug Place": "lakewood-co"
+    },
+    {
+      "ID Place": "16000US0664224",
+      Place: "Salinas, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.095214870965943,
+      "Slug Place": "salinas-ca"
+    },
+    {
+      "ID Place": "16000US5101000",
+      Place: "Alexandria, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.86963331105914,
+      "Slug Place": "alexandria-va"
+    },
+    {
+      "ID Place": "16000US0877290",
+      Place: "Thornton, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.088072567314654,
+      "Slug Place": "thornton-co"
+    },
+    {
+      "ID Place": "16000US0883835",
+      Place: "Westminster, CO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.20683024635561,
+      "Slug Place": "westminster-co"
+    },
+    {
+      "ID Place": "16000US5182000",
+      Place: "Virginia Beach, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.588803398088164,
+      "Slug Place": "virginia-beach-va"
+    },
+    {
+      "ID Place": "16000US0908000",
+      Place: "Bridgeport, CT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.31549913902138,
+      "Slug Place": "bridgeport-ct"
+    },
+    {
+      "ID Place": "16000US0664000",
+      Place: "Sacramento, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.880182827293503,
+      "Slug Place": "sacramento-ca"
+    },
+    {
+      "ID Place": "16000US4983470",
+      Place: "West Valley City, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.05050942017095,
+      "Slug Place": "west-valley-city-ut"
+    },
+    {
+      "ID Place": "16000US0937000",
+      Place: "Hartford, CT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.851975793523565,
+      "Slug Place": "hartford-ct"
+    },
+    {
+      "ID Place": "16000US0952000",
+      Place: "New Haven, CT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.317051749763547,
+      "Slug Place": "new-haven-ct"
+    },
+    {
+      "ID Place": "16000US0662000",
+      Place: "Riverside, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.377416881774128,
+      "Slug Place": "riverside-ca"
+    },
+    {
+      "ID Place": "16000US4967440",
+      Place: "Sandy, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.4099165233441,
+      "Slug Place": "sandy-ut"
+    },
+    {
+      "ID Place": "16000US0973000",
+      Place: "Stamford, CT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.455786471067643,
+      "Slug Place": "stamford-ct"
+    },
+    {
+      "ID Place": "16000US1077580",
+      Place: "Wilmington, DE",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.47368601973119,
+      "Slug Place": "wilmington-de"
+    },
+    {
+      "ID Place": "16000US1150000",
+      Place: "Washington, DC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.964823690516948,
+      "Slug Place": "washington-dc"
+    },
+    {
+      "ID Place": "16000US5303180",
+      Place: "Auburn, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 32.422173212316565,
+      "Slug Place": "auburn-wa"
+    },
+    {
+      "ID Place": "16000US1212875",
+      Place: "Clearwater, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.804680692144903,
+      "Slug Place": "clearwater-fl"
+    },
+    {
+      "ID Place": "16000US0660620",
+      Place: "Richmond, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 35.444585295182904,
+      "Slug Place": "richmond-ca"
+    },
+    {
+      "ID Place": "16000US1224000",
+      Place: "Fort Lauderdale, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.117704057746955,
+      "Slug Place": "fort-lauderdale-fl"
+    },
+    {
+      "ID Place": "16000US4967000",
+      Place: "Salt Lake City, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.214101201817382,
+      "Slug Place": "salt-lake-city-ut"
+    },
+    {
+      "ID Place": "16000US1225175",
+      Place: "Gainesville, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.216390687028362,
+      "Slug Place": "gainesville-fl"
+    },
+    {
+      "ID Place": "16000US1230000",
+      Place: "Hialeah, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.948402601074356,
+      "Slug Place": "hialeah-fl"
+    },
+    {
+      "ID Place": "16000US0660102",
+      Place: "Redwood City, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.118920692200444,
+      "Slug Place": "redwood-city-ca"
+    },
+    {
+      "ID Place": "16000US1232000",
+      Place: "Hollywood, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.123240219082103,
+      "Slug Place": "hollywood-fl"
+    },
+    {
+      "ID Place": "16000US1235000",
+      Place: "Jacksonville, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.54032204640951,
+      "Slug Place": "jacksonville-fl"
+    },
+    {
+      "ID Place": "16000US0659451",
+      Place: "Rancho Cucamonga, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.739083500397395,
+      "Slug Place": "rancho-cucamonga-ca"
+    },
+    {
+      "ID Place": "16000US4962470",
+      Place: "Provo, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.451359460546257,
+      "Slug Place": "provo-ut"
+    },
+    {
+      "ID Place": "16000US1245000",
+      Place: "Miami, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.68718571346628,
+      "Slug Place": "miami-fl"
+    },
+    {
+      "ID Place": "16000US1245025",
+      Place: "Miami Beach, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.04353803849679,
+      "Slug Place": "miami-beach-fl"
+    },
+    {
+      "ID Place": "16000US5305210",
+      Place: "Bellevue, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.260475698612545,
+      "Slug Place": "bellevue-wa"
+    },
+    {
+      "ID Place": "16000US1253000",
+      Place: "Orlando, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.471126627665598,
+      "Slug Place": "orlando-fl"
+    },
+    {
+      "ID Place": "16000US1258050",
+      Place: "Pompano Beach, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.64704675963905,
+      "Slug Place": "pompano-beach-fl"
+    },
+    {
+      "ID Place": "16000US0658072",
+      Place: "Pomona, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.712815363373917,
+      "Slug Place": "pomona-ca"
+    },
+    {
+      "ID Place": "16000US1263000",
+      Place: "St. Petersburg, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.256587088401293,
+      "Slug Place": "st.-petersburg-fl"
+    },
+    {
+      "ID Place": "16000US4957300",
+      Place: "Orem, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.06744526166303,
+      "Slug Place": "orem-ut"
+    },
+    {
+      "ID Place": "16000US1270600",
+      Place: "Tallahassee, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.376429078502632,
+      "Slug Place": "tallahassee-fl"
+    },
+    {
+      "ID Place": "16000US1271000",
+      Place: "Tampa, FL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.23078929984957,
+      "Slug Place": "tampa-fl"
+    },
+    {
+      "ID Place": "16000US0657792",
+      Place: "Pleasanton, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.910022808903335,
+      "Slug Place": "pleasanton-ca"
+    },
+    {
+      "ID Place": "16000US1303440",
+      Place: "Athens-Clarke County unified government (balance), GA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.267361171802627,
+      "Slug Place": "athens-clarke-county-unified-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US0657456",
+      Place: "Pittsburg, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 40.78688420518029,
+      "Slug Place": "pittsburg-ca"
+    },
+    {
+      "ID Place": "16000US1304000",
+      Place: "Atlanta, GA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.421187244926184,
+      "Slug Place": "atlanta-ga"
+    },
+    {
+      "ID Place": "16000US0656000",
+      Place: "Pasadena, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.82716133424098,
+      "Slug Place": "pasadena-ca"
+    },
+    {
+      "ID Place": "16000US4955980",
+      Place: "Ogden, UT",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.273664727657323,
+      "Slug Place": "ogden-ut"
+    },
+    {
+      "ID Place": "16000US1319000",
+      Place: "Columbus, GA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.130526217946482,
+      "Slug Place": "columbus-ga"
+    },
+    {
+      "ID Place": "16000US0655282",
+      Place: "Palo Alto, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.146960944367702,
+      "Slug Place": "palo-alto-ca"
+    },
+    {
+      "ID Place": "16000US0655156",
+      Place: "Palmdale, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 40.01100969862001,
+      "Slug Place": "palmdale-ca"
+    },
+    {
+      "ID Place": "16000US1369000",
+      Place: "Savannah, GA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.00293034788489,
+      "Slug Place": "savannah-ga"
+    },
+    {
+      "ID Place": "16000US5305280",
+      Place: "Bellingham, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.003345918205863,
+      "Slug Place": "bellingham-wa"
+    },
+    {
+      "ID Place": "16000US1571550",
+      Place: "Urban Honolulu, HI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.00999722299361,
+      "Slug Place": "urban-honolulu-hi"
+    },
+    {
+      "ID Place": "16000US0654652",
+      Place: "Oxnard, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.160974900869853,
+      "Slug Place": "oxnard-ca"
+    },
+    {
+      "ID Place": "16000US4865000",
+      Place: "San Antonio, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.779112375773842,
+      "Slug Place": "san-antonio-tx"
+    },
+    {
+      "ID Place": "16000US1608830",
+      Place: "Boise City, ID",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.336839371510194,
+      "Slug Place": "boise-city-id"
+    },
+    {
+      "ID Place": "16000US1703012",
+      Place: "Aurora, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.5283795562183,
+      "Slug Place": "aurora-il"
+    },
+    {
+      "ID Place": "16000US0653980",
+      Place: "Orange, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.85358453288174,
+      "Slug Place": "orange-ca"
+    },
+    {
+      "ID Place": "16000US1712385",
+      Place: "Champaign, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.661449399656947,
+      "Slug Place": "champaign-il"
+    },
+    {
+      "ID Place": "16000US4861796",
+      Place: "Richardson, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.049341706890885,
+      "Slug Place": "richardson-tx"
+    },
+    {
+      "ID Place": "16000US1714000",
+      Place: "Chicago, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.363123218293204,
+      "Slug Place": "chicago-il"
+    },
+    {
+      "ID Place": "16000US1714351",
+      Place: "Cicero, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.486531986531986,
+      "Slug Place": "cicero-il"
+    },
+    {
+      "ID Place": "16000US0653896",
+      Place: "Ontario, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.21264163857132,
+      "Slug Place": "ontario-ca"
+    },
+    {
+      "ID Place": "16000US1723074",
+      Place: "Elgin, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.59482278715903,
+      "Slug Place": "elgin-il"
+    },
+    {
+      "ID Place": "16000US0653322",
+      Place: "Oceanside, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.875221003172758,
+      "Slug Place": "oceanside-ca"
+    },
+    {
+      "ID Place": "16000US1724582",
+      Place: "Evanston, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.36292112731462,
+      "Slug Place": "evanston-il"
+    },
+    {
+      "ID Place": "16000US4858016",
+      Place: "Plano, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.753842120785137,
+      "Slug Place": "plano-tx"
+    },
+    {
+      "ID Place": "16000US1738570",
+      Place: "Joliet, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.77797195284411,
+      "Slug Place": "joliet-il"
+    },
+    {
+      "ID Place": "16000US5322640",
+      Place: "Everett, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.869270435446907,
+      "Slug Place": "everett-wa"
+    },
+    {
+      "ID Place": "16000US1751622",
+      Place: "Naperville, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.732815575870344,
+      "Slug Place": "naperville-il"
+    },
+    {
+      "ID Place": "16000US0653000",
+      Place: "Oakland, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.530612339584472,
+      "Slug Place": "oakland-ca"
+    },
+    {
+      "ID Place": "16000US1765000",
+      Place: "Rockford, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.042227162942467,
+      "Slug Place": "rockford-il"
+    },
+    {
+      "ID Place": "16000US1770122",
+      Place: "Skokie, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.884038429125233,
+      "Slug Place": "skokie-il"
+    },
+    {
+      "ID Place": "16000US0652526",
+      Place: "Norwalk, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.345574613691344,
+      "Slug Place": "norwalk-ca"
+    },
+    {
+      "ID Place": "16000US1772000",
+      Place: "Springfield, IL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.31632439029041,
+      "Slug Place": "springfield-il"
+    },
+    {
+      "ID Place": "16000US0650258",
+      Place: "Napa, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.02493521732753,
+      "Slug Place": "napa-ca"
+    },
+    {
+      "ID Place": "16000US0649670",
+      Place: "Mountain View, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.438654883507404,
+      "Slug Place": "mountain-view-ca"
+    },
+    {
+      "ID Place": "16000US4845000",
+      Place: "Lubbock, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.961142723841737,
+      "Slug Place": "lubbock-tx"
+    },
+    {
+      "ID Place": "16000US1825000",
+      Place: "Fort Wayne, IN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.24748456296588,
+      "Slug Place": "fort-wayne-in"
+    },
+    {
+      "ID Place": "16000US1836003",
+      Place: "Indianapolis city (balance), IN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.905171467262015,
+      "Slug Place": "indianapolis-city-(balance)-in"
+    },
+    {
+      "ID Place": "16000US1871000",
+      Place: "South Bend, IN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.597065248361666,
+      "Slug Place": "south-bend-in"
+    },
+    {
+      "ID Place": "16000US0649270",
+      Place: "Moreno Valley, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.739789814445565,
+      "Slug Place": "moreno-valley-ca"
+    },
+    {
+      "ID Place": "16000US1912000",
+      Place: "Cedar Rapids, IA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.49525020460657,
+      "Slug Place": "cedar-rapids-ia"
+    },
+    {
+      "ID Place": "16000US1921000",
+      Place: "Des Moines, IA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.712816845155718,
+      "Slug Place": "des-moines-ia"
+    },
+    {
+      "ID Place": "16000US5335415",
+      Place: "Kent, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.703969460812267,
+      "Slug Place": "kent-wa"
+    },
+    {
+      "ID Place": "16000US4841464",
+      Place: "Laredo, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.35865776321868,
+      "Slug Place": "laredo-tx"
+    },
+    {
+      "ID Place": "16000US1938595",
+      Place: "Iowa City, IA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.441046208355887,
+      "Slug Place": "iowa-city-ia"
+    },
+    {
+      "ID Place": "16000US0648354",
+      Place: "Modesto, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.683816988435556,
+      "Slug Place": "modesto-ca"
+    },
+    {
+      "ID Place": "16000US2036000",
+      Place: "Kansas City, KS",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.959701577701065,
+      "Slug Place": "kansas-city-ks"
+    },
+    {
+      "ID Place": "16000US2038900",
+      Place: "Lawrence, KS",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.719713312770775,
+      "Slug Place": "lawrence-ks"
+    },
+    {
+      "ID Place": "16000US2052575",
+      Place: "Olathe, KS",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.619577992947892,
+      "Slug Place": "olathe-ks"
+    },
+    {
+      "ID Place": "16000US2071000",
+      Place: "Topeka, KS",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.1441357043679,
+      "Slug Place": "topeka-ks"
+    },
+    {
+      "ID Place": "16000US0644574",
+      Place: "Lynwood, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.78548647072945,
+      "Slug Place": "lynwood-ca"
+    },
+    {
+      "ID Place": "16000US2079000",
+      Place: "Wichita, KS",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.74687537984283,
+      "Slug Place": "wichita-ks"
+    },
+    {
+      "ID Place": "16000US0644000",
+      Place: "Los Angeles, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.776073247791604,
+      "Slug Place": "los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US2146027",
+      Place: "Lexington-Fayette, KY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.124766349431297,
+      "Slug Place": "lexington-fayette-ky"
+    },
+    {
+      "ID Place": "16000US4837000",
+      Place: "Irving, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.025333778643056,
+      "Slug Place": "irving-tx"
+    },
+    {
+      "ID Place": "16000US2148006",
+      Place: "Louisville/Jefferson County metro government (balance), KY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.525641715365527,
+      "Slug Place": "louisville-jefferson-county-metro-government-(balance)-ky"
+    },
+    {
+      "ID Place": "16000US2205000",
+      Place: "Baton Rouge, LA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.989164700517478,
+      "Slug Place": "baton-rouge-la"
+    },
+    {
+      "ID Place": "16000US0643000",
+      Place: "Long Beach, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.284561317930866,
+      "Slug Place": "long-beach-ca"
+    },
+    {
+      "ID Place": "16000US2255000",
+      Place: "New Orleans, LA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.38727759495789,
+      "Slug Place": "new-orleans-la"
+    },
+    {
+      "ID Place": "16000US5335940",
+      Place: "Kirkland, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.222425705485723,
+      "Slug Place": "kirkland-wa"
+    },
+    {
+      "ID Place": "16000US4835000",
+      Place: "Houston, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.371616586004492,
+      "Slug Place": "houston-tx"
+    },
+    {
+      "ID Place": "16000US2270000",
+      Place: "Shreveport, LA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.878011087671098,
+      "Slug Place": "shreveport-la"
+    },
+    {
+      "ID Place": "16000US0641992",
+      Place: "Livermore, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.975229889818575,
+      "Slug Place": "livermore-ca"
+    },
+    {
+      "ID Place": "16000US2360545",
+      Place: "Portland, ME",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.57602324657262,
+      "Slug Place": "portland-me"
+    },
+    {
+      "ID Place": "16000US2404000",
+      Place: "Baltimore, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.8570617656824,
+      "Slug Place": "baltimore-md"
+    },
+    {
+      "ID Place": "16000US0640130",
+      Place: "Lancaster, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 32.30697896242913,
+      "Slug Place": "lancaster-ca"
+    },
+    {
+      "ID Place": "16000US4830464",
+      Place: "Grand Prairie, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.691245325876164,
+      "Slug Place": "grand-prairie-tx"
+    },
+    {
+      "ID Place": "16000US2419125",
+      Place: "Columbia, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.6652280008632,
+      "Slug Place": "columbia-md"
+    },
+    {
+      "ID Place": "16000US0636770",
+      Place: "Irvine, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.53055701417781,
+      "Slug Place": "irvine-ca"
+    },
+    {
+      "ID Place": "16000US2431175",
+      Place: "Gaithersburg, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.662666277248228,
+      "Slug Place": "gaithersburg-md"
+    },
+    {
+      "ID Place": "16000US5157000",
+      Place: "Norfolk, VA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.928472920221594,
+      "Slug Place": "norfolk-va"
+    },
+    {
+      "ID Place": "16000US4829000",
+      Place: "Garland, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.591620415526574,
+      "Slug Place": "garland-tx"
+    },
+    {
+      "ID Place": "16000US0669088",
+      Place: "Santa Clarita, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.0880886365878,
+      "Slug Place": "santa-clarita-ca"
+    },
+    {
+      "ID Place": "16000US0636546",
+      Place: "Inglewood, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.328062419708306,
+      "Slug Place": "inglewood-ca"
+    },
+    {
+      "ID Place": "16000US2467675",
+      Place: "Rockville, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.77911408486491,
+      "Slug Place": "rockville-md"
+    },
+    {
+      "ID Place": "16000US2472450",
+      Place: "Silver Spring, MD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.34290210765369,
+      "Slug Place": "silver-spring-md"
+    },
+    {
+      "ID Place": "16000US0636000",
+      Place: "Huntington Beach, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.560257436959198,
+      "Slug Place": "huntington-beach-ca"
+    },
+    {
+      "ID Place": "16000US2507000",
+      Place: "Boston, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.95674465347683,
+      "Slug Place": "boston-ma"
+    },
+    {
+      "ID Place": "16000US2509000",
+      Place: "Brockton, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.974669924458095,
+      "Slug Place": "brockton-ma"
+    },
+    {
+      "ID Place": "16000US0633000",
+      Place: "Hayward, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.99342745537202,
+      "Slug Place": "hayward-ca"
+    },
+    {
+      "ID Place": "16000US4827000",
+      Place: "Fort Worth, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.673063993336743,
+      "Slug Place": "fort-worth-tx"
+    },
+    {
+      "ID Place": "16000US2511000",
+      Place: "Cambridge, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.187038226790875,
+      "Slug Place": "cambridge-ma"
+    },
+    {
+      "ID Place": "16000US2523000",
+      Place: "Fall River, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.88448978490271,
+      "Slug Place": "fall-river-ma"
+    },
+    {
+      "ID Place": "16000US2534550",
+      Place: "Lawrence, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.833280366109452,
+      "Slug Place": "lawrence-ma"
+    },
+    {
+      "ID Place": "16000US5363000",
+      Place: "Seattle, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.608587587332103,
+      "Slug Place": "seattle-wa"
+    },
+    {
+      "ID Place": "16000US0630000",
+      Place: "Glendale, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.198807469009886,
+      "Slug Place": "glendale-ca"
+    },
+    {
+      "ID Place": "16000US2537000",
+      Place: "Lowell, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.007163070392643,
+      "Slug Place": "lowell-ma"
+    },
+    {
+      "ID Place": "16000US4824000",
+      Place: "El Paso, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.593609431804957,
+      "Slug Place": "el-paso-tx"
+    },
+    {
+      "ID Place": "16000US2537490",
+      Place: "Lynn, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.776781154947713,
+      "Slug Place": "lynn-ma"
+    },
+    {
+      "ID Place": "16000US0629000",
+      Place: "Garden Grove, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.267059429829697,
+      "Slug Place": "garden-grove-ca"
+    },
+    {
+      "ID Place": "16000US2545000",
+      Place: "New Bedford, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.75753607314634,
+      "Slug Place": "new-bedford-ma"
+    },
+    {
+      "ID Place": "16000US2545560",
+      Place: "Newton, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.15958563409848,
+      "Slug Place": "newton-ma"
+    },
+    {
+      "ID Place": "16000US2555745",
+      Place: "Quincy, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 36.741463903074,
+      "Slug Place": "quincy-ma"
+    },
+    {
+      "ID Place": "16000US0628000",
+      Place: "Fullerton, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.889277557746233,
+      "Slug Place": "fullerton-ca"
+    },
+    {
+      "ID Place": "16000US2562535",
+      Place: "Somerville, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.887484375275083,
+      "Slug Place": "somerville-ma"
+    },
+    {
+      "ID Place": "16000US5367000",
+      Place: "Spokane, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.355402931350138,
+      "Slug Place": "spokane-wa"
+    },
+    {
+      "ID Place": "16000US4819972",
+      Place: "Denton, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.747191579799615,
+      "Slug Place": "denton-tx"
+    },
+    {
+      "ID Place": "16000US2567000",
+      Place: "Springfield, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.447858694445767,
+      "Slug Place": "springfield-ma"
+    },
+    {
+      "ID Place": "16000US2582000",
+      Place: "Worcester, MA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.094674424058336,
+      "Slug Place": "worcester-ma"
+    },
+    {
+      "ID Place": "16000US0627000",
+      Place: "Fresno, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.174274593064403,
+      "Slug Place": "fresno-ca"
+    },
+    {
+      "ID Place": "16000US2603000",
+      Place: "Ann Arbor, MI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.47427170798761,
+      "Slug Place": "ann-arbor-mi"
+    },
+    {
+      "ID Place": "16000US0626000",
+      Place: "Fremont, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.445719996100223,
+      "Slug Place": "fremont-ca"
+    },
+    {
+      "ID Place": "16000US2622000",
+      Place: "Detroit, MI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.32862813346593,
+      "Slug Place": "detroit-mi"
+    },
+    {
+      "ID Place": "16000US0624680",
+      Place: "Fontana, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.32045651334801,
+      "Slug Place": "fontana-ca"
+    },
+    {
+      "ID Place": "16000US4819000",
+      Place: "Dallas, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.382841265486228,
+      "Slug Place": "dallas-tx"
+    },
+    {
+      "ID Place": "16000US2634000",
+      Place: "Grand Rapids, MI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.218208304512775,
+      "Slug Place": "grand-rapids-mi"
+    },
+    {
+      "ID Place": "16000US2646000",
+      Place: "Lansing, MI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.00693717509714,
+      "Slug Place": "lansing-mi"
+    },
+    {
+      "ID Place": "16000US2684000",
+      Place: "Warren, MI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.676470588235293,
+      "Slug Place": "warren-mi"
+    },
+    {
+      "ID Place": "16000US2706616",
+      Place: "Bloomington, MN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.600523235189783,
+      "Slug Place": "bloomington-mn"
+    },
+    {
+      "ID Place": "16000US2717000",
+      Place: "Duluth, MN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.194998072693467,
+      "Slug Place": "duluth-mn"
+    },
+    {
+      "ID Place": "16000US5370000",
+      Place: "Tacoma, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.604493492354134,
+      "Slug Place": "tacoma-wa"
+    },
+    {
+      "ID Place": "16000US0622804",
+      Place: "Escondido, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.043949748332448,
+      "Slug Place": "escondido-ca"
+    },
+    {
+      "ID Place": "16000US4817000",
+      Place: "Corpus Christi, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.2233551111991,
+      "Slug Place": "corpus-christi-tx"
+    },
+    {
+      "ID Place": "16000US2743000",
+      Place: "Minneapolis, MN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.044369486248055,
+      "Slug Place": "minneapolis-mn"
+    },
+    {
+      "ID Place": "16000US2754880",
+      Place: "Rochester, MN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.32454020673916,
+      "Slug Place": "rochester-mn"
+    },
+    {
+      "ID Place": "16000US0622230",
+      Place: "El Monte, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.129295446324505,
+      "Slug Place": "el-monte-ca"
+    },
+    {
+      "ID Place": "16000US2758000",
+      Place: "St. Paul, MN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.932838508322664,
+      "Slug Place": "st.-paul-mn"
+    },
+    {
+      "ID Place": "16000US0622020",
+      Place: "Elk Grove, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.35247643925425,
+      "Slug Place": "elk-grove-ca"
+    },
+    {
+      "ID Place": "16000US4815976",
+      Place: "College Station, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.37710880079211,
+      "Slug Place": "college-station-tx"
+    },
+    {
+      "ID Place": "16000US2938000",
+      Place: "Kansas City, MO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.975319350905476,
+      "Slug Place": "kansas-city-mo"
+    },
+    {
+      "ID Place": "16000US2965000",
+      Place: "St. Louis, MO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.937465698143665,
+      "Slug Place": "st.-louis-mo"
+    },
+    {
+      "ID Place": "16000US5374060",
+      Place: "Vancouver, WA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.317703246706845,
+      "Slug Place": "vancouver-wa"
+    },
+    {
+      "ID Place": "16000US2970000",
+      Place: "Springfield, MO",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.991287451422842,
+      "Slug Place": "springfield-mo"
+    },
+    {
+      "ID Place": "16000US0619766",
+      Place: "Downey, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.178707155524993,
+      "Slug Place": "downey-ca"
+    },
+    {
+      "ID Place": "16000US4810768",
+      Place: "Brownsville, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.72365472572674,
+      "Slug Place": "brownsville-tx"
+    },
+    {
+      "ID Place": "16000US3128000",
+      Place: "Lincoln, NE",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.327176299655335,
+      "Slug Place": "lincoln-ne"
+    },
+    {
+      "ID Place": "16000US0617918",
+      Place: "Daly City, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 29.71597450128009,
+      "Slug Place": "daly-city-ca"
+    },
+    {
+      "ID Place": "16000US3137000",
+      Place: "Omaha, NE",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.076533774474175,
+      "Slug Place": "omaha-ne"
+    },
+    {
+      "ID Place": "16000US0616532",
+      Place: "Costa Mesa, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.654342935355473,
+      "Slug Place": "costa-mesa-ca"
+    },
+    {
+      "ID Place": "16000US3231900",
+      Place: "Henderson, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.627363693665302,
+      "Slug Place": "henderson-nv"
+    },
+    {
+      "ID Place": "16000US0616350",
+      Place: "Corona, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 36.37770374662032,
+      "Slug Place": "corona-ca"
+    },
+    {
+      "ID Place": "16000US3240000",
+      Place: "Las Vegas, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.44240397745177,
+      "Slug Place": "las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US0616000",
+      Place: "Concord, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.18529142893169,
+      "Slug Place": "concord-ca"
+    },
+    {
+      "ID Place": "16000US4805000",
+      Place: "Austin, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.739073525958982,
+      "Slug Place": "austin-tx"
+    },
+    {
+      "ID Place": "16000US3251800",
+      Place: "North Las Vegas, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.912587478189085,
+      "Slug Place": "north-las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US3254600",
+      Place: "Paradise, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.313082551030636,
+      "Slug Place": "paradise-nv"
+    },
+    {
+      "ID Place": "16000US3260600",
+      Place: "Reno, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.17629441174813,
+      "Slug Place": "reno-nv"
+    },
+    {
+      "ID Place": "16000US5531000",
+      Place: "Green Bay, WI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.518641930835734,
+      "Slug Place": "green-bay-wi"
+    },
+    {
+      "ID Place": "16000US3268400",
+      Place: "Sparks, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.900457042223994,
+      "Slug Place": "sparks-nv"
+    },
+    {
+      "ID Place": "16000US0613588",
+      Place: "Citrus Heights, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.6364520653305,
+      "Slug Place": "citrus-heights-ca"
+    },
+    {
+      "ID Place": "16000US3268585",
+      Place: "Spring Valley, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.610954434859543,
+      "Slug Place": "spring-valley-nv"
+    },
+    {
+      "ID Place": "16000US0613392",
+      Place: "Chula Vista, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.768384822028207,
+      "Slug Place": "chula-vista-ca"
+    },
+    {
+      "ID Place": "16000US4804000",
+      Place: "Arlington, TX",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.906099143790815,
+      "Slug Place": "arlington-tx"
+    },
+    {
+      "ID Place": "16000US3271400",
+      Place: "Sunrise Manor, NV",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.401475173902615,
+      "Slug Place": "sunrise-manor-nv"
+    },
+    {
+      "ID Place": "16000US3345140",
+      Place: "Manchester, NH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.14657508880023,
+      "Slug Place": "manchester-nh"
+    },
+    {
+      "ID Place": "16000US3403580",
+      Place: "Bayonne, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 36.765976723116594,
+      "Slug Place": "bayonne-nj"
+    },
+    {
+      "ID Place": "16000US0613014",
+      Place: "Chico, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 15.762002677888294,
+      "Slug Place": "chico-ca"
+    },
+    {
+      "ID Place": "16000US0611530",
+      Place: "Carson, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.8954093496025,
+      "Slug Place": "carson-ca"
+    },
+    {
+      "ID Place": "16000US3421000",
+      Place: "Elizabeth, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.882191735317566,
+      "Slug Place": "elizabeth-nj"
+    },
+    {
+      "ID Place": "16000US3436000",
+      Place: "Jersey City, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 37.26306244449254,
+      "Slug Place": "jersey-city-nj"
+    },
+    {
+      "ID Place": "16000US0608954",
+      Place: "Burbank, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.543484241138096,
+      "Slug Place": "burbank-la-county-ca"
+    },
+    {
+      "ID Place": "16000US3451000",
+      Place: "Newark, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.11296429939682,
+      "Slug Place": "newark-nj"
+    },
+    {
+      "ID Place": "16000US0606000",
+      Place: "Berkeley, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.9449406660712,
+      "Slug Place": "berkeley-ca"
+    },
+    {
+      "ID Place": "16000US3456550",
+      Place: "Passaic, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.471464512711865,
+      "Slug Place": "passaic-nj"
+    },
+    {
+      "ID Place": "16000US4752006",
+      Place: "Nashville-Davidson metropolitan government (balance), TN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.597187680719717,
+      "Slug Place": "nashville-davidson-metropolitan-government-(balance)-tn"
+    },
+    {
+      "ID Place": "16000US3457000",
+      Place: "Paterson, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.684962106102912,
+      "Slug Place": "paterson-nj"
+    },
+    {
+      "ID Place": "16000US3474630",
+      Place: "Union City, NJ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 33.20793822812246,
+      "Slug Place": "union-city-nj"
+    },
+    {
+      "ID Place": "16000US0603526",
+      Place: "Bakersfield, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.136300054680248,
+      "Slug Place": "bakersfield-ca"
+    },
+    {
+      "ID Place": "16000US3502000",
+      Place: "Albuquerque, NM",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.52956311699223,
+      "Slug Place": "albuquerque-nm"
+    },
+    {
+      "ID Place": "16000US4748000",
+      Place: "Memphis, TN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.96392681575607,
+      "Slug Place": "memphis-tn"
+    },
+    {
+      "ID Place": "16000US3611000",
+      Place: "Buffalo, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.868113280494878,
+      "Slug Place": "buffalo-ny"
+    },
+    {
+      "ID Place": "16000US0602553",
+      Place: "Arden-Arcade, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.547752301859543,
+      "Slug Place": "arden-arcade-ca"
+    },
+    {
+      "ID Place": "16000US3649121",
+      Place: "Mount Vernon, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.39132441162898,
+      "Slug Place": "mount-vernon-ny"
+    },
+    {
+      "ID Place": "16000US3650617",
+      Place: "New Rochelle, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 30.738669727219346,
+      "Slug Place": "new-rochelle-ny"
+    },
+    {
+      "ID Place": "16000US5548000",
+      Place: "Madison, WI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.529155164775243,
+      "Slug Place": "madison-wi"
+    },
+    {
+      "ID Place": "16000US0602000",
+      Place: "Anaheim, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 28.440117911965523,
+      "Slug Place": "anaheim-ca"
+    },
+    {
+      "ID Place": "16000US3651000",
+      Place: "New York, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 39.57584665091657,
+      "Slug Place": "new-york-ny"
+    },
+    {
+      "ID Place": "16000US3663000",
+      Place: "Rochester, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.1266194545112,
+      "Slug Place": "rochester-ny"
+    },
+    {
+      "ID Place": "16000US3673000",
+      Place: "Syracuse, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.092080559822495,
+      "Slug Place": "syracuse-ny"
+    },
+    {
+      "ID Place": "16000US0600562",
+      Place: "Alameda, CA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.334440615781254,
+      "Slug Place": "alameda-ca"
+    },
+    {
+      "ID Place": "16000US3684000",
+      Place: "Yonkers, NY",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 34.12052467476615,
+      "Slug Place": "yonkers-ny"
+    },
+    {
+      "ID Place": "16000US0541000",
+      Place: "Little Rock, AR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.37522930971225,
+      "Slug Place": "little-rock-ar"
+    },
+    {
+      "ID Place": "16000US3712000",
+      Place: "Charlotte, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.71372351622203,
+      "Slug Place": "charlotte-nc"
+    },
+    {
+      "ID Place": "16000US5553000",
+      Place: "Milwaukee, WI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.264697537483098,
+      "Slug Place": "milwaukee-wi"
+    },
+    {
+      "ID Place": "16000US3719000",
+      Place: "Durham, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.625823727688076,
+      "Slug Place": "durham-nc"
+    },
+    {
+      "ID Place": "16000US0477000",
+      Place: "Tucson, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.775393455118056,
+      "Slug Place": "tucson-az"
+    },
+    {
+      "ID Place": "16000US4714000",
+      Place: "Chattanooga, TN",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.312026837701314,
+      "Slug Place": "chattanooga-tn"
+    },
+    {
+      "ID Place": "16000US3722920",
+      Place: "Fayetteville, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.467573840124363,
+      "Slug Place": "fayetteville-nc"
+    },
+    {
+      "ID Place": "16000US3728000",
+      Place: "Greensboro, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.75422197203129,
+      "Slug Place": "greensboro-nc"
+    },
+    {
+      "ID Place": "16000US0473000",
+      Place: "Tempe, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.995005234898038,
+      "Slug Place": "tempe-az"
+    },
+    {
+      "ID Place": "16000US3755000",
+      Place: "Raleigh, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.592709267387168,
+      "Slug Place": "raleigh-nc"
+    },
+    {
+      "ID Place": "16000US0465000",
+      Place: "Scottsdale, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.412950048653908,
+      "Slug Place": "scottsdale-az"
+    },
+    {
+      "ID Place": "16000US3774440",
+      Place: "Wilmington, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.001214272370632,
+      "Slug Place": "wilmington-nc"
+    },
+    {
+      "ID Place": "16000US4659020",
+      Place: "Sioux Falls, SD",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 16.335189660607334,
+      "Slug Place": "sioux-falls-sd"
+    },
+    {
+      "ID Place": "16000US3775000",
+      Place: "Winston-Salem, NC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.597937663307203,
+      "Slug Place": "winston-salem-nc"
+    },
+    {
+      "ID Place": "16000US0455000",
+      Place: "Phoenix, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.57751974259167,
+      "Slug Place": "phoenix-az"
+    },
+    {
+      "ID Place": "16000US3901000",
+      Place: "Akron, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.67941922101867,
+      "Slug Place": "akron-oh"
+    },
+    {
+      "ID Place": "16000US3915000",
+      Place: "Cincinnati, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.618103111804988,
+      "Slug Place": "cincinnati-oh"
+    },
+    {
+      "ID Place": "16000US0454050",
+      Place: "Peoria, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.813209466695223,
+      "Slug Place": "peoria-az"
+    },
+    {
+      "ID Place": "16000US3916000",
+      Place: "Cleveland, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.540434959296306,
+      "Slug Place": "cleveland-oh"
+    },
+    {
+      "ID Place": "16000US0446000",
+      Place: "Mesa, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.272046636818867,
+      "Slug Place": "mesa-az"
+    },
+    {
+      "ID Place": "16000US4516000",
+      Place: "Columbia, SC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 14.826442174186289,
+      "Slug Place": "columbia-sc"
+    },
+    {
+      "ID Place": "16000US3918000",
+      Place: "Columbus, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.83280639129696,
+      "Slug Place": "columbus-oh"
+    },
+    {
+      "ID Place": "16000US3921000",
+      Place: "Dayton, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.09529322320904,
+      "Slug Place": "dayton-oh"
+    },
+    {
+      "ID Place": "16000US3977000",
+      Place: "Toledo, OH",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.440800316434835,
+      "Slug Place": "toledo-oh"
+    },
+    {
+      "ID Place": "16000US7206593",
+      Place: "Bayamón, PR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.02666388555735,
+      "Slug Place": "bayamón-pr"
+    },
+    {
+      "ID Place": "16000US0427820",
+      Place: "Glendale, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 26.738463253006884,
+      "Slug Place": "glendale-az"
+    },
+    {
+      "ID Place": "16000US4055000",
+      Place: "Oklahoma City, OK",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.879532328128626,
+      "Slug Place": "oklahoma-city-ok"
+    },
+    {
+      "ID Place": "16000US0427400",
+      Place: "Gilbert, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.284939621781728,
+      "Slug Place": "gilbert-az"
+    },
+    {
+      "ID Place": "16000US4075000",
+      Place: "Tulsa, OK",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.064097486834783,
+      "Slug Place": "tulsa-ok"
+    },
+    {
+      "ID Place": "16000US4513330",
+      Place: "Charleston, SC",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 20.880432755083007,
+      "Slug Place": "charleston-sc"
+    },
+    {
+      "ID Place": "16000US4105350",
+      Place: "Beaverton, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.43277433965211,
+      "Slug Place": "beaverton-or"
+    },
+    {
+      "ID Place": "16000US4123850",
+      Place: "Eugene, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.03480806766428,
+      "Slug Place": "eugene-or"
+    },
+    {
+      "ID Place": "16000US0412000",
+      Place: "Chandler, AZ",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.949278829721784,
+      "Slug Place": "chandler-az"
+    },
+    {
+      "ID Place": "16000US4131250",
+      Place: "Gresham, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.295395483327844,
+      "Slug Place": "gresham-or"
+    },
+    {
+      "ID Place": "16000US7214290",
+      Place: "Carolina, PR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 27.150829647050042,
+      "Slug Place": "carolina-pr"
+    },
+    {
+      "ID Place": "16000US4134100",
+      Place: "Hillsboro, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.452276335708746,
+      "Slug Place": "hillsboro-or"
+    },
+    {
+      "ID Place": "16000US0203000",
+      Place: "Anchorage, AK",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 17.171629717636947,
+      "Slug Place": "anchorage-ak"
+    },
+    {
+      "ID Place": "16000US4459000",
+      Place: "Providence, RI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.237975412504067,
+      "Slug Place": "providence-ri"
+    },
+    {
+      "ID Place": "16000US4159000",
+      Place: "Portland, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 25.230835685077462,
+      "Slug Place": "portland-or"
+    },
+    {
+      "ID Place": "16000US4164900",
+      Place: "Salem, OR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.056646615942316,
+      "Slug Place": "salem-or"
+    },
+    {
+      "ID Place": "16000US0151000",
+      Place: "Montgomery, AL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.914861643108143,
+      "Slug Place": "montgomery-al"
+    },
+    {
+      "ID Place": "16000US4202000",
+      Place: "Allentown, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.081900397436936,
+      "Slug Place": "allentown-pa"
+    },
+    {
+      "ID Place": "16000US4454640",
+      Place: "Pawtucket, RI",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.81605542672278,
+      "Slug Place": "pawtucket-ri"
+    },
+    {
+      "ID Place": "16000US4224000",
+      Place: "Erie, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 18.41616663387763,
+      "Slug Place": "erie-pa"
+    },
+    {
+      "ID Place": "16000US0150000",
+      Place: "Mobile, AL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.100074066994793,
+      "Slug Place": "mobile-al"
+    },
+    {
+      "ID Place": "16000US4269000",
+      Place: "Scranton, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 19.4881577340984,
+      "Slug Place": "scranton-pa"
+    },
+    {
+      "ID Place": "16000US4260000",
+      Place: "Philadelphia, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 31.868617193089438,
+      "Slug Place": "philadelphia-pa"
+    },
+    {
+      "ID Place": "16000US7276770",
+      Place: "San Juan, PR",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 24.32382052668666,
+      "Slug Place": "san-juan-pr"
+    },
+    {
+      "ID Place": "16000US4261000",
+      Place: "Pittsburgh, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 22.896731778406604,
+      "Slug Place": "pittsburgh-pa"
+    },
+    {
+      "ID Place": "16000US0107000",
+      Place: "Birmingham, AL",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 21.349229936420663,
+      "Slug Place": "birmingham-al"
+    },
+    {
+      "ID Place": "16000US4263624",
+      Place: "Reading, PA",
+      "ID Year": 2016,
+      Year: "2016",
+      "Average Commute Time": 23.220474917439848,
+      "Slug Place": "reading-pa"
+    },
+    {
+      "ID Place": "16000US0668000",
+      Place: "San Jose, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.118084466905625,
+      "Slug Place": "san-jose-ca"
+    },
+    {
+      "ID Place": "16000US2432025",
+      Place: "Germantown, MD",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 35.46847960444994,
+      "Slug Place": "germantown-md"
+    },
+    {
+      "ID Place": "16000US0658072",
+      Place: "Pomona, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.523172919189907,
+      "Slug Place": "pomona-ca"
+    },
+    {
+      "ID Place": "16000US5103000",
+      Place: "Arlington, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.147371474750823,
+      "Slug Place": "arlington-va"
+    },
+    {
+      "ID Place": "16000US1270600",
+      Place: "Tallahassee, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.197626418988648,
+      "Slug Place": "tallahassee-fl"
+    },
+    {
+      "ID Place": "16000US0636546",
+      Place: "Inglewood, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.75693469825807,
+      "Slug Place": "inglewood-ca"
+    },
+    {
+      "ID Place": "16000US4829000",
+      Place: "Garland, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.034052786526086,
+      "Slug Place": "garland-tx"
+    },
+    {
+      "ID Place": "16000US2472450",
+      Place: "Silver Spring, MD",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.051128153829055,
+      "Slug Place": "silver-spring-md"
+    },
+    {
+      "ID Place": "16000US0675000",
+      Place: "Stockton, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.679083094555875,
+      "Slug Place": "stockton-ca"
+    },
+    {
+      "ID Place": "16000US0107000",
+      Place: "Birmingham, AL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.496208480187974,
+      "Slug Place": "birmingham-al"
+    },
+    {
+      "ID Place": "16000US2507000",
+      Place: "Boston, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.465820233888586,
+      "Slug Place": "boston-ma"
+    },
+    {
+      "ID Place": "16000US4957300",
+      Place: "Orem, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.703078566121842,
+      "Slug Place": "orem-ut"
+    },
+    {
+      "ID Place": "16000US0636000",
+      Place: "Huntington Beach, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.948229337362992,
+      "Slug Place": "huntington-beach-ca"
+    },
+    {
+      "ID Place": "16000US5363000",
+      Place: "Seattle, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.47947643490663,
+      "Slug Place": "seattle-wa"
+    },
+    {
+      "ID Place": "16000US2509000",
+      Place: "Brockton, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.431760076476735,
+      "Slug Place": "brockton-ma"
+    },
+    {
+      "ID Place": "16000US1271000",
+      Place: "Tampa, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.86361989961652,
+      "Slug Place": "tampa-fl"
+    },
+    {
+      "ID Place": "16000US5182000",
+      Place: "Virginia Beach, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.343323336339424,
+      "Slug Place": "virginia-beach-va"
+    },
+    {
+      "ID Place": "16000US0843000",
+      Place: "Lakewood, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.35995341779299,
+      "Slug Place": "lakewood-co"
+    },
+    {
+      "ID Place": "16000US2511000",
+      Place: "Cambridge, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.169646964548058,
+      "Slug Place": "cambridge-ma"
+    },
+    {
+      "ID Place": "16000US1276600",
+      Place: "West Palm Beach, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.31582614928226,
+      "Slug Place": "west-palm-beach-fl"
+    },
+    {
+      "ID Place": "16000US0633000",
+      Place: "Hayward, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.23128956967757,
+      "Slug Place": "hayward-ca"
+    },
+    {
+      "ID Place": "16000US0657792",
+      Place: "Pleasanton, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.79283323593476,
+      "Slug Place": "pleasanton-ca"
+    },
+    {
+      "ID Place": "16000US4827000",
+      Place: "Fort Worth, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.81606929939972,
+      "Slug Place": "fort-worth-tx"
+    },
+    {
+      "ID Place": "16000US2524960",
+      Place: "Framingham, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.361691226700497,
+      "Slug Place": "framingham-ma"
+    },
+    {
+      "ID Place": "16000US2534550",
+      Place: "Lawrence, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.29172274562584,
+      "Slug Place": "lawrence-ma"
+    },
+    {
+      "ID Place": "16000US1303440",
+      Place: "Athens-Clarke County unified government (balance), GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.091541343275555,
+      "Slug Place": "athens-clarke-county-unified-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US0670098",
+      Place: "Santa Rosa, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.739528256338392,
+      "Slug Place": "santa-rosa-ca"
+    },
+    {
+      "ID Place": "16000US0684200",
+      Place: "West Covina, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.01210801726443,
+      "Slug Place": "west-covina-ca"
+    },
+    {
+      "ID Place": "16000US2537000",
+      Place: "Lowell, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.456705910428763,
+      "Slug Place": "lowell-ma"
+    },
+    {
+      "ID Place": "16000US1304000",
+      Place: "Atlanta, GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.830545376158653,
+      "Slug Place": "atlanta-ga"
+    },
+    {
+      "ID Place": "16000US0630000",
+      Place: "Glendale, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.304133283811748,
+      "Slug Place": "glendale-ca"
+    },
+    {
+      "ID Place": "16000US0664224",
+      Place: "Salinas, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.069720875613502,
+      "Slug Place": "salinas-ca"
+    },
+    {
+      "ID Place": "16000US2537490",
+      Place: "Lynn, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.751948135585945,
+      "Slug Place": "lynn-ma"
+    },
+    {
+      "ID Place": "16000US0669088",
+      Place: "Santa Clarita, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.635125733028527,
+      "Slug Place": "santa-clarita-ca"
+    },
+    {
+      "ID Place": "16000US0862000",
+      Place: "Pueblo, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.50957051709361,
+      "Slug Place": "pueblo-co"
+    },
+    {
+      "ID Place": "16000US2545000",
+      Place: "New Bedford, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.847373568035763,
+      "Slug Place": "new-bedford-ma"
+    },
+    {
+      "ID Place": "16000US1304204",
+      Place: "Augusta-Richmond County consolidated government (balance), GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.97473888753947,
+      "Slug Place":
+        "augusta-richmond-county-consolidated-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US0629000",
+      Place: "Garden Grove, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.989888206506095,
+      "Slug Place": "garden-grove-ca"
+    },
+    {
+      "ID Place": "16000US4824000",
+      Place: "El Paso, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.74075323905063,
+      "Slug Place": "el-paso-tx"
+    },
+    {
+      "ID Place": "16000US2545560",
+      Place: "Newton, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.696569018579734,
+      "Slug Place": "newton-ma"
+    },
+    {
+      "ID Place": "16000US0656000",
+      Place: "Pasadena, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.568906552036445,
+      "Slug Place": "pasadena-ca"
+    },
+    {
+      "ID Place": "16000US5367000",
+      Place: "Spokane, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.94307473153627,
+      "Slug Place": "spokane-wa"
+    },
+    {
+      "ID Place": "16000US2555745",
+      Place: "Quincy, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 35.81941244239631,
+      "Slug Place": "quincy-ma"
+    },
+    {
+      "ID Place": "16000US4955980",
+      Place: "Ogden, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.17041555470835,
+      "Slug Place": "ogden-ut"
+    },
+    {
+      "ID Place": "16000US1319000",
+      Place: "Columbus, GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.39926357704855,
+      "Slug Place": "columbus-ga"
+    },
+    {
+      "ID Place": "16000US0628000",
+      Place: "Fullerton, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.10058571097193,
+      "Slug Place": "fullerton-ca"
+    },
+    {
+      "ID Place": "16000US2562535",
+      Place: "Somerville, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.95481578183928,
+      "Slug Place": "somerville-ma"
+    },
+    {
+      "ID Place": "16000US5101000",
+      Place: "Alexandria, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.391459918744456,
+      "Slug Place": "alexandria-va"
+    },
+    {
+      "ID Place": "16000US0684550",
+      Place: "Westminster, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.95990485898743,
+      "Slug Place": "westminster-ca"
+    },
+    {
+      "ID Place": "16000US1349008",
+      Place: "Macon-Bibb County, GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.974776107139924,
+      "Slug Place": "macon-bibb-county-ga"
+    },
+    {
+      "ID Place": "16000US2567000",
+      Place: "Springfield, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.31293583013398,
+      "Slug Place": "springfield-ma"
+    },
+    {
+      "ID Place": "16000US5305280",
+      Place: "Bellingham, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 15.75449708042946,
+      "Slug Place": "bellingham-wa"
+    },
+    {
+      "ID Place": "16000US4819972",
+      Place: "Denton, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.263783783783783,
+      "Slug Place": "denton-tx"
+    },
+    {
+      "ID Place": "16000US2582000",
+      Place: "Worcester, MA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.837433590197673,
+      "Slug Place": "worcester-ma"
+    },
+    {
+      "ID Place": "16000US0685292",
+      Place: "Whittier, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.434618628185905,
+      "Slug Place": "whittier-ca"
+    },
+    {
+      "ID Place": "16000US1369000",
+      Place: "Savannah, GA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.466537254128816,
+      "Slug Place": "savannah-ga"
+    },
+    {
+      "ID Place": "16000US2603000",
+      Place: "Ann Arbor, MI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.284883214602964,
+      "Slug Place": "ann-arbor-mi"
+    },
+    {
+      "ID Place": "16000US0677000",
+      Place: "Sunnyvale, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.20490777380245,
+      "Slug Place": "sunnyvale-ca"
+    },
+    {
+      "ID Place": "16000US0627000",
+      Place: "Fresno, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.18586125967438,
+      "Slug Place": "fresno-ca"
+    },
+    {
+      "ID Place": "16000US0655156",
+      Place: "Palmdale, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 41.520067727500475,
+      "Slug Place": "palmdale-ca"
+    },
+    {
+      "ID Place": "16000US0626000",
+      Place: "Fremont, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.36292459941158,
+      "Slug Place": "fremont-ca"
+    },
+    {
+      "ID Place": "16000US2622000",
+      Place: "Detroit, MI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.857724800370328,
+      "Slug Place": "detroit-mi"
+    },
+    {
+      "ID Place": "16000US0908000",
+      Place: "Bridgeport, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.817325516555393,
+      "Slug Place": "bridgeport-ct"
+    },
+    {
+      "ID Place": "16000US1571550",
+      Place: "Urban Honolulu, HI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.192190072924017,
+      "Slug Place": "urban-honolulu-hi"
+    },
+    {
+      "ID Place": "16000US0624680",
+      Place: "Fontana, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.153130503162068,
+      "Slug Place": "fontana-ca"
+    },
+    {
+      "ID Place": "16000US0803455",
+      Place: "Arvada, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.15633107373002,
+      "Slug Place": "arvada-co"
+    },
+    {
+      "ID Place": "16000US2634000",
+      Place: "Grand Rapids, MI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.740952736473176,
+      "Slug Place": "grand-rapids-mi"
+    },
+    {
+      "ID Place": "16000US0669070",
+      Place: "Santa Barbara, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.132856627809158,
+      "Slug Place": "santa-barbara-ca"
+    },
+    {
+      "ID Place": "16000US5370000",
+      Place: "Tacoma, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.932921171429467,
+      "Slug Place": "tacoma-wa"
+    },
+    {
+      "ID Place": "16000US4819000",
+      Place: "Dallas, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.551298625548718,
+      "Slug Place": "dallas-tx"
+    },
+    {
+      "ID Place": "16000US0664000",
+      Place: "Sacramento, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.656829198072465,
+      "Slug Place": "sacramento-ca"
+    },
+    {
+      "ID Place": "16000US2684000",
+      Place: "Warren, MI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.707227425938786,
+      "Slug Place": "warren-mi"
+    },
+    {
+      "ID Place": "16000US1608830",
+      Place: "Boise City, ID",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.418068624233985,
+      "Slug Place": "boise-city-id"
+    },
+    {
+      "ID Place": "16000US0624477",
+      Place: "Florence-Graham, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.164411953122055,
+      "Slug Place": "florence-graham-ca"
+    },
+    {
+      "ID Place": "16000US2706616",
+      Place: "Bloomington, MN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.016779940056566,
+      "Slug Place": "bloomington-mn"
+    },
+    {
+      "ID Place": "16000US0918430",
+      Place: "Danbury, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.80145451197901,
+      "Slug Place": "danbury-ct"
+    },
+    {
+      "ID Place": "16000US0623182",
+      Place: "Fairfield, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.025008585338263,
+      "Slug Place": "fairfield-ca"
+    },
+    {
+      "ID Place": "16000US2717000",
+      Place: "Duluth, MN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.157806753594116,
+      "Slug Place": "duluth-mn"
+    },
+    {
+      "ID Place": "16000US0654652",
+      Place: "Oxnard, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.68355119825708,
+      "Slug Place": "oxnard-ca"
+    },
+    {
+      "ID Place": "16000US4865000",
+      Place: "San Antonio, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.75936421421459,
+      "Slug Place": "san-antonio-tx"
+    },
+    {
+      "ID Place": "16000US1703012",
+      Place: "Aurora, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.942653394740752,
+      "Slug Place": "aurora-il"
+    },
+    {
+      "ID Place": "16000US0669084",
+      Place: "Santa Clara, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.88430295415364,
+      "Slug Place": "santa-clara-ca"
+    },
+    {
+      "ID Place": "16000US2743000",
+      Place: "Minneapolis, MN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.677758910507833,
+      "Slug Place": "minneapolis-mn"
+    },
+    {
+      "ID Place": "16000US5121088",
+      Place: "Dale City, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 41.29053978229155,
+      "Slug Place": "dale-city-va"
+    },
+    {
+      "ID Place": "16000US0622804",
+      Place: "Escondido, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.80180743830379,
+      "Slug Place": "escondido-ca"
+    },
+    {
+      "ID Place": "16000US4817000",
+      Place: "Corpus Christi, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.639155788218144,
+      "Slug Place": "corpus-christi-tx"
+    },
+    {
+      "ID Place": "16000US2754880",
+      Place: "Rochester, MN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 15.789035087719299,
+      "Slug Place": "rochester-mn"
+    },
+    {
+      "ID Place": "16000US1712385",
+      Place: "Champaign, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 14.406938584153774,
+      "Slug Place": "champaign-il"
+    },
+    {
+      "ID Place": "16000US4982950",
+      Place: "West Jordan, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.14252564079854,
+      "Slug Place": "west-jordan-ut"
+    },
+    {
+      "ID Place": "16000US2758000",
+      Place: "St. Paul, MN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.2480501494278,
+      "Slug Place": "st.-paul-mn"
+    },
+    {
+      "ID Place": "16000US0653980",
+      Place: "Orange, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.03776925778506,
+      "Slug Place": "orange-ca"
+    },
+    {
+      "ID Place": "16000US0952000",
+      Place: "New Haven, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.35830889457714,
+      "Slug Place": "new-haven-ct"
+    },
+    {
+      "ID Place": "16000US0622020",
+      Place: "Elk Grove, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.157511642164856,
+      "Slug Place": "elk-grove-ca"
+    },
+    {
+      "ID Place": "16000US1714000",
+      Place: "Chicago, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.42210319808177,
+      "Slug Place": "chicago-il"
+    },
+    {
+      "ID Place": "16000US2915670",
+      Place: "Columbia, MO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.603089354383346,
+      "Slug Place": "columbia-mo"
+    },
+    {
+      "ID Place": "16000US5374060",
+      Place: "Vancouver, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.895510903156143,
+      "Slug Place": "vancouver-wa"
+    },
+    {
+      "ID Place": "16000US2938000",
+      Place: "Kansas City, MO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.647928569620145,
+      "Slug Place": "kansas-city-mo"
+    },
+    {
+      "ID Place": "16000US0804000",
+      Place: "Aurora, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.692020611944756,
+      "Slug Place": "aurora-co"
+    },
+    {
+      "ID Place": "16000US0621712",
+      Place: "El Cajon, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.727829798953458,
+      "Slug Place": "el-cajon-ca"
+    },
+    {
+      "ID Place": "16000US0620802",
+      Place: "East Los Angeles, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.3694298982314,
+      "Slug Place": "east-los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US2965000",
+      Place: "St. Louis, MO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.00645385427384,
+      "Slug Place": "st.-louis-mo"
+    },
+    {
+      "ID Place": "16000US5322640",
+      Place: "Everett, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.86878564117561,
+      "Slug Place": "everett-wa"
+    },
+    {
+      "ID Place": "16000US4861796",
+      Place: "Richardson, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.794368264652178,
+      "Slug Place": "richardson-tx"
+    },
+    {
+      "ID Place": "16000US2970000",
+      Place: "Springfield, MO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.045073663673428,
+      "Slug Place": "springfield-mo"
+    },
+    {
+      "ID Place": "16000US1714351",
+      Place: "Cicero, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.973802001053187,
+      "Slug Place": "cicero-il"
+    },
+    {
+      "ID Place": "16000US0662938",
+      Place: "Roseville, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.80156945069226,
+      "Slug Place": "roseville-ca"
+    },
+    {
+      "ID Place": "16000US0619766",
+      Place: "Downey, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.919320480461128,
+      "Slug Place": "downey-ca"
+    },
+    {
+      "ID Place": "16000US3006550",
+      Place: "Billings, MT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.77730155411527,
+      "Slug Place": "billings-mt"
+    },
+    {
+      "ID Place": "16000US0618100",
+      Place: "Davis, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.587284144427002,
+      "Slug Place": "davis-ca"
+    },
+    {
+      "ID Place": "16000US0955990",
+      Place: "Norwalk, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.845792756994914,
+      "Slug Place": "norwalk-ct"
+    },
+    {
+      "ID Place": "16000US3128000",
+      Place: "Lincoln, NE",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.259195922610065,
+      "Slug Place": "lincoln-ne"
+    },
+    {
+      "ID Place": "16000US0668252",
+      Place: "San Mateo, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.31717645348309,
+      "Slug Place": "san-mateo-ca"
+    },
+    {
+      "ID Place": "16000US0653896",
+      Place: "Ontario, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.366397727843964,
+      "Slug Place": "ontario-ca"
+    },
+    {
+      "ID Place": "16000US4810768",
+      Place: "Brownsville, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.202205126699358,
+      "Slug Place": "brownsville-tx"
+    },
+    {
+      "ID Place": "16000US3137000",
+      Place: "Omaha, NE",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.998870071576963,
+      "Slug Place": "omaha-ne"
+    },
+    {
+      "ID Place": "16000US0672016",
+      Place: "Simi Valley, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.69608224939637,
+      "Slug Place": "simi-valley-ca"
+    },
+    {
+      "ID Place": "16000US0617918",
+      Place: "Daly City, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.633811333794057,
+      "Slug Place": "daly-city-ca"
+    },
+    {
+      "ID Place": "16000US1724582",
+      Place: "Evanston, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.838201886842878,
+      "Slug Place": "evanston-il"
+    },
+    {
+      "ID Place": "16000US3231900",
+      Place: "Henderson, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.449607249831896,
+      "Slug Place": "henderson-nv"
+    },
+    {
+      "ID Place": "16000US0973000",
+      Place: "Stamford, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.45228026060121,
+      "Slug Place": "stamford-ct"
+    },
+    {
+      "ID Place": "16000US0653322",
+      Place: "Oceanside, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.624281103642407,
+      "Slug Place": "oceanside-ca"
+    },
+    {
+      "ID Place": "16000US0616350",
+      Place: "Corona, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.955392225429485,
+      "Slug Place": "corona-ca"
+    },
+    {
+      "ID Place": "16000US3240000",
+      Place: "Las Vegas, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.106842064808003,
+      "Slug Place": "las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US0670000",
+      Place: "Santa Monica, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.107870424059687,
+      "Slug Place": "santa-monica-ca"
+    },
+    {
+      "ID Place": "16000US0662000",
+      Place: "Riverside, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.229692069974064,
+      "Slug Place": "riverside-ca"
+    },
+    {
+      "ID Place": "16000US0980000",
+      Place: "Waterbury, CT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.458271526050343,
+      "Slug Place": "waterbury-ct"
+    },
+    {
+      "ID Place": "16000US3251800",
+      Place: "North Las Vegas, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.968911917098445,
+      "Slug Place": "north-las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US4858016",
+      Place: "Plano, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.23474876808033,
+      "Slug Place": "plano-tx"
+    },
+    {
+      "ID Place": "16000US0616000",
+      Place: "Concord, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.760773227383865,
+      "Slug Place": "concord-ca"
+    },
+    {
+      "ID Place": "16000US4805000",
+      Place: "Austin, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.239415410343593,
+      "Slug Place": "austin-tx"
+    },
+    {
+      "ID Place": "16000US3254600",
+      Place: "Paradise, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.93720720720721,
+      "Slug Place": "paradise-nv"
+    },
+    {
+      "ID Place": "16000US0807850",
+      Place: "Boulder, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.44332203273159,
+      "Slug Place": "boulder-co"
+    },
+    {
+      "ID Place": "16000US5531000",
+      Place: "Green Bay, WI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.599643013121167,
+      "Slug Place": "green-bay-wi"
+    },
+    {
+      "ID Place": "16000US3260600",
+      Place: "Reno, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.87313653448203,
+      "Slug Place": "reno-nv"
+    },
+    {
+      "ID Place": "16000US4967440",
+      Place: "Sandy, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.55936982114801,
+      "Slug Place": "sandy-ut"
+    },
+    {
+      "ID Place": "16000US1759000",
+      Place: "Peoria, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.724642327575843,
+      "Slug Place": "peoria-il"
+    },
+    {
+      "ID Place": "16000US3268400",
+      Place: "Sparks, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.603368411584817,
+      "Slug Place": "sparks-nv"
+    },
+    {
+      "ID Place": "16000US1150000",
+      Place: "Washington, DC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.0331285774117,
+      "Slug Place": "washington-dc"
+    },
+    {
+      "ID Place": "16000US0653000",
+      Place: "Oakland, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.212249503392105,
+      "Slug Place": "oakland-ca"
+    },
+    {
+      "ID Place": "16000US3268585",
+      Place: "Spring Valley, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.216591112406647,
+      "Slug Place": "spring-valley-nv"
+    },
+    {
+      "ID Place": "16000US1768003",
+      Place: "Schaumburg, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.7569805554871,
+      "Slug Place": "schaumburg-il"
+    },
+    {
+      "ID Place": "16000US4845384",
+      Place: "McAllen, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.39487444898542,
+      "Slug Place": "mcallen-tx"
+    },
+    {
+      "ID Place": "16000US1770122",
+      Place: "Skokie, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.474716486849815,
+      "Slug Place": "skokie-il"
+    },
+    {
+      "ID Place": "16000US3271400",
+      Place: "Sunrise Manor, NV",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.161512730423063,
+      "Slug Place": "sunrise-manor-nv"
+    },
+    {
+      "ID Place": "16000US0668084",
+      Place: "San Leandro, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.288276069921636,
+      "Slug Place": "san-leandro-ca"
+    },
+    {
+      "ID Place": "16000US0613392",
+      Place: "Chula Vista, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.296326558117205,
+      "Slug Place": "chula-vista-ca"
+    },
+    {
+      "ID Place": "16000US3345140",
+      Place: "Manchester, NH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.41968465987331,
+      "Slug Place": "manchester-nh"
+    },
+    {
+      "ID Place": "16000US0667000",
+      Place: "San Francisco, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.807564575274625,
+      "Slug Place": "san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US4804000",
+      Place: "Arlington, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.698578050940153,
+      "Slug Place": "arlington-tx"
+    },
+    {
+      "ID Place": "16000US3403580",
+      Place: "Bayonne, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.461054979218055,
+      "Slug Place": "bayonne-nj"
+    },
+    {
+      "ID Place": "16000US1772000",
+      Place: "Springfield, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.351464970481256,
+      "Slug Place": "springfield-il"
+    },
+    {
+      "ID Place": "16000US1212875",
+      Place: "Clearwater, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.67764611750362,
+      "Slug Place": "clearwater-fl"
+    },
+    {
+      "ID Place": "16000US0613014",
+      Place: "Chico, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 15.306558013193635,
+      "Slug Place": "chico-ca"
+    },
+    {
+      "ID Place": "16000US0652526",
+      Place: "Norwalk, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.26439413898628,
+      "Slug Place": "norwalk-ca"
+    },
+    {
+      "ID Place": "16000US4803000",
+      Place: "Amarillo, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.062991719495322,
+      "Slug Place": "amarillo-tx"
+    },
+    {
+      "ID Place": "16000US3421000",
+      Place: "Elizabeth, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.402316562207833,
+      "Slug Place": "elizabeth-nj"
+    },
+    {
+      "ID Place": "16000US1779293",
+      Place: "Waukegan, IL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.423345872470055,
+      "Slug Place": "waukegan-il"
+    },
+    {
+      "ID Place": "16000US0611530",
+      Place: "Carson, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.14927447094467,
+      "Slug Place": "carson-ca"
+    },
+    {
+      "ID Place": "16000US3436000",
+      Place: "Jersey City, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 35.09445421007763,
+      "Slug Place": "jersey-city-nj"
+    },
+    {
+      "ID Place": "16000US5116000",
+      Place: "Chesapeake, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.858547038206613,
+      "Slug Place": "chesapeake-va"
+    },
+    {
+      "ID Place": "16000US0650258",
+      Place: "Napa, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.398809523809526,
+      "Slug Place": "napa-ca"
+    },
+    {
+      "ID Place": "16000US3451000",
+      Place: "Newark, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 36.065351350860794,
+      "Slug Place": "newark-nj"
+    },
+    {
+      "ID Place": "16000US1214400",
+      Place: "Coral Springs, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 27.399512109568075,
+      "Slug Place": "coral-springs-fl"
+    },
+    {
+      "ID Place": "16000US5539225",
+      Place: "Kenosha, WI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.610583016476554,
+      "Slug Place": "kenosha-wi"
+    },
+    {
+      "ID Place": "16000US0812815",
+      Place: "Centennial, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.42179694766941,
+      "Slug Place": "centennial-co"
+    },
+    {
+      "ID Place": "16000US3456550",
+      Place: "Passaic, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.100456996994524,
+      "Slug Place": "passaic-nj"
+    },
+    {
+      "ID Place": "16000US1825000",
+      Place: "Fort Wayne, IN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.246113816798985,
+      "Slug Place": "fort-wayne-in"
+    },
+    {
+      "ID Place": "16000US0606000",
+      Place: "Berkeley, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.382466977722284,
+      "Slug Place": "berkeley-ca"
+    },
+    {
+      "ID Place": "16000US1224000",
+      Place: "Fort Lauderdale, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.656395335249712,
+      "Slug Place": "fort-lauderdale-fl"
+    },
+    {
+      "ID Place": "16000US3457000",
+      Place: "Paterson, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.377329730478763,
+      "Slug Place": "paterson-nj"
+    },
+    {
+      "ID Place": "16000US0649670",
+      Place: "Mountain View, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.564178787557065,
+      "Slug Place": "mountain-view-ca"
+    },
+    {
+      "ID Place": "16000US0604982",
+      Place: "Bellflower, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.72805991846538,
+      "Slug Place": "bellflower-ca"
+    },
+    {
+      "ID Place": "16000US4752006",
+      Place: "Nashville-Davidson metropolitan government (balance), TN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.12237347942094,
+      "Slug Place": "nashville-davidson-metropolitan-government-(balance)-tn"
+    },
+    {
+      "ID Place": "16000US3474000",
+      Place: "Trenton, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.274970963995354,
+      "Slug Place": "trenton-nj"
+    },
+    {
+      "ID Place": "16000US3474630",
+      Place: "Union City, NJ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.107249472790514,
+      "Slug Place": "union-city-nj"
+    },
+    {
+      "ID Place": "16000US1831000",
+      Place: "Hammond, IN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.6420162994265,
+      "Slug Place": "hammond-in"
+    },
+    {
+      "ID Place": "16000US4845000",
+      Place: "Lubbock, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.78042217661935,
+      "Slug Place": "lubbock-tx"
+    },
+    {
+      "ID Place": "16000US0603526",
+      Place: "Bakersfield, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.658372691080835,
+      "Slug Place": "bakersfield-ca"
+    },
+    {
+      "ID Place": "16000US3502000",
+      Place: "Albuquerque, NM",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.96418882675959,
+      "Slug Place": "albuquerque-nm"
+    },
+    {
+      "ID Place": "16000US1836003",
+      Place: "Indianapolis city (balance), IN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.357984257169594,
+      "Slug Place": "indianapolis-city-(balance)-in"
+    },
+    {
+      "ID Place": "16000US5548000",
+      Place: "Madison, WI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.118132155639742,
+      "Slug Place": "madison-wi"
+    },
+    {
+      "ID Place": "16000US3601000",
+      Place: "Albany, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.838574978612456,
+      "Slug Place": "albany-ny"
+    },
+    {
+      "ID Place": "16000US0669000",
+      Place: "Santa Ana, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.242440276197783,
+      "Slug Place": "santa-ana-ca"
+    },
+    {
+      "ID Place": "16000US3611000",
+      Place: "Buffalo, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.883006998795214,
+      "Slug Place": "buffalo-ny"
+    },
+    {
+      "ID Place": "16000US5335415",
+      Place: "Kent, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.19238144765495,
+      "Slug Place": "kent-wa"
+    },
+    {
+      "ID Place": "16000US1871000",
+      Place: "South Bend, IN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.01820212171971,
+      "Slug Place": "south-bend-in"
+    },
+    {
+      "ID Place": "16000US4748000",
+      Place: "Memphis, TN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.809937467485536,
+      "Slug Place": "memphis-tn"
+    },
+    {
+      "ID Place": "16000US3649121",
+      Place: "Mount Vernon, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 34.16411018691293,
+      "Slug Place": "mount-vernon-ny"
+    },
+    {
+      "ID Place": "16000US0660620",
+      Place: "Richmond, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 34.579804180589015,
+      "Slug Place": "richmond-ca"
+    },
+    {
+      "ID Place": "16000US0602553",
+      Place: "Arden-Arcade, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.942585369191814,
+      "Slug Place": "arden-arcade-ca"
+    },
+    {
+      "ID Place": "16000US3650617",
+      Place: "New Rochelle, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.26754476229677,
+      "Slug Place": "new-rochelle-ny"
+    },
+    {
+      "ID Place": "16000US5157000",
+      Place: "Norfolk, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.961024168384576,
+      "Slug Place": "norfolk-va"
+    },
+    {
+      "ID Place": "16000US1912000",
+      Place: "Cedar Rapids, IA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.852568189868933,
+      "Slug Place": "cedar-rapids-ia"
+    },
+    {
+      "ID Place": "16000US1225175",
+      Place: "Gainesville, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.427760328581783,
+      "Slug Place": "gainesville-fl"
+    },
+    {
+      "ID Place": "16000US3651000",
+      Place: "New York, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 39.21281732359668,
+      "Slug Place": "new-york-ny"
+    },
+    {
+      "ID Place": "16000US1919000",
+      Place: "Davenport, IA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.276867222093976,
+      "Slug Place": "davenport-ia"
+    },
+    {
+      "ID Place": "16000US0602000",
+      Place: "Anaheim, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.806109899289925,
+      "Slug Place": "anaheim-ca"
+    },
+    {
+      "ID Place": "16000US4740000",
+      Place: "Knoxville, TN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.67925229674473,
+      "Slug Place": "knoxville-tn"
+    },
+    {
+      "ID Place": "16000US3663000",
+      Place: "Rochester, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.847669620668636,
+      "Slug Place": "rochester-ny"
+    },
+    {
+      "ID Place": "16000US0649270",
+      Place: "Moreno Valley, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 32.26756120472706,
+      "Slug Place": "moreno-valley-ca"
+    },
+    {
+      "ID Place": "16000US0600884",
+      Place: "Alhambra, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.40353663450826,
+      "Slug Place": "alhambra-ca"
+    },
+    {
+      "ID Place": "16000US3665508",
+      Place: "Schenectady, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.45080376940133,
+      "Slug Place": "schenectady-ny"
+    },
+    {
+      "ID Place": "16000US3673000",
+      Place: "Syracuse, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.42313099928833,
+      "Slug Place": "syracuse-ny"
+    },
+    {
+      "ID Place": "16000US1921000",
+      Place: "Des Moines, IA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.76646960627888,
+      "Slug Place": "des-moines-ia"
+    },
+    {
+      "ID Place": "16000US0666000",
+      Place: "San Diego, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.46714417184479,
+      "Slug Place": "san-diego-ca"
+    },
+    {
+      "ID Place": "16000US0600562",
+      Place: "Alameda, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.293698212485555,
+      "Slug Place": "alameda-ca"
+    },
+    {
+      "ID Place": "16000US3684000",
+      Place: "Yonkers, NY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.09306943515141,
+      "Slug Place": "yonkers-ny"
+    },
+    {
+      "ID Place": "16000US0660466",
+      Place: "Rialto, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.571428571428573,
+      "Slug Place": "rialto-ca"
+    },
+    {
+      "ID Place": "16000US5553000",
+      Place: "Milwaukee, WI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.715576040292156,
+      "Slug Place": "milwaukee-wi"
+    },
+    {
+      "ID Place": "16000US4715160",
+      Place: "Clarksville, TN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.07047291979681,
+      "Slug Place": "clarksville-tn"
+    },
+    {
+      "ID Place": "16000US3710740",
+      Place: "Cary, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.58500583430572,
+      "Slug Place": "cary-nc"
+    },
+    {
+      "ID Place": "16000US4967000",
+      Place: "Salt Lake City, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.663698486323465,
+      "Slug Place": "salt-lake-city-ut"
+    },
+    {
+      "ID Place": "16000US3712000",
+      Place: "Charlotte, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.866070788594694,
+      "Slug Place": "charlotte-nc"
+    },
+    {
+      "ID Place": "16000US1230000",
+      Place: "Hialeah, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.436788088481126,
+      "Slug Place": "hialeah-fl"
+    },
+    {
+      "ID Place": "16000US0541000",
+      Place: "Little Rock, AR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.521368318514373,
+      "Slug Place": "little-rock-ar"
+    },
+    {
+      "ID Place": "16000US0816000",
+      Place: "Colorado Springs, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.770198093435198,
+      "Slug Place": "colorado-springs-co"
+    },
+    {
+      "ID Place": "16000US3719000",
+      Place: "Durham, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.091449881479022,
+      "Slug Place": "durham-nc"
+    },
+    {
+      "ID Place": "16000US4841464",
+      Place: "Laredo, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.26358929249715,
+      "Slug Place": "laredo-tx"
+    },
+    {
+      "ID Place": "16000US2036000",
+      Place: "Kansas City, KS",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.1664658461715,
+      "Slug Place": "kansas-city-ks"
+    },
+    {
+      "ID Place": "16000US0681204",
+      Place: "Union City, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 35.6569663145306,
+      "Slug Place": "union-city-ca"
+    },
+    {
+      "ID Place": "16000US3722920",
+      Place: "Fayetteville, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.409474819908674,
+      "Slug Place": "fayetteville-nc"
+    },
+    {
+      "ID Place": "16000US1232000",
+      Place: "Hollywood, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.77581405608095,
+      "Slug Place": "hollywood-fl"
+    },
+    {
+      "ID Place": "16000US0477000",
+      Place: "Tucson, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.378095742956404,
+      "Slug Place": "tucson-az"
+    },
+    {
+      "ID Place": "16000US4714000",
+      Place: "Chattanooga, TN",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.690899615660218,
+      "Slug Place": "chattanooga-tn"
+    },
+    {
+      "ID Place": "16000US3728000",
+      Place: "Greensboro, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.651061549795728,
+      "Slug Place": "greensboro-nc"
+    },
+    {
+      "ID Place": "16000US0648354",
+      Place: "Modesto, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.56021313959922,
+      "Slug Place": "modesto-ca"
+    },
+    {
+      "ID Place": "16000US0673262",
+      Place: "South San Francisco, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.776606213974414,
+      "Slug Place": "south-san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US3755000",
+      Place: "Raleigh, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.80450503398579,
+      "Slug Place": "raleigh-nc"
+    },
+    {
+      "ID Place": "16000US2053775",
+      Place: "Overland Park, KS",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.499234609650923,
+      "Slug Place": "overland-park-ks"
+    },
+    {
+      "ID Place": "16000US0473000",
+      Place: "Tempe, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.468611993891617,
+      "Slug Place": "tempe-az"
+    },
+    {
+      "ID Place": "16000US0660102",
+      Place: "Redwood City, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.98467741935484,
+      "Slug Place": "redwood-city-ca"
+    },
+    {
+      "ID Place": "16000US3774440",
+      Place: "Wilmington, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.692445029129864,
+      "Slug Place": "wilmington-nc"
+    },
+    {
+      "ID Place": "16000US5305210",
+      Place: "Bellevue, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.03429195888838,
+      "Slug Place": "bellevue-wa"
+    },
+    {
+      "ID Place": "16000US2079000",
+      Place: "Wichita, KS",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.47286775982069,
+      "Slug Place": "wichita-ks"
+    },
+    {
+      "ID Place": "16000US3775000",
+      Place: "Winston-Salem, NC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.946135496183206,
+      "Slug Place": "winston-salem-nc"
+    },
+    {
+      "ID Place": "16000US1235000",
+      Place: "Jacksonville, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.616385685429343,
+      "Slug Place": "jacksonville-fl"
+    },
+    {
+      "ID Place": "16000US0644574",
+      Place: "Lynwood, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.725355682471022,
+      "Slug Place": "lynwood-ca"
+    },
+    {
+      "ID Place": "16000US4659020",
+      Place: "Sioux Falls, SD",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.288957950850495,
+      "Slug Place": "sioux-falls-sd"
+    },
+    {
+      "ID Place": "16000US0455000",
+      Place: "Phoenix, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.56072045467209,
+      "Slug Place": "phoenix-az"
+    },
+    {
+      "ID Place": "16000US5135000",
+      Place: "Hampton, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.97852193995381,
+      "Slug Place": "hampton-va"
+    },
+    {
+      "ID Place": "16000US7206593",
+      Place: "Bayamón, PR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.783532758764956,
+      "Slug Place": "bayamón-pr"
+    },
+    {
+      "ID Place": "16000US3915000",
+      Place: "Cincinnati, OH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.951717706961116,
+      "Slug Place": "cincinnati-oh"
+    },
+    {
+      "ID Place": "16000US2146027",
+      Place: "Lexington-Fayette, KY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.735727399481398,
+      "Slug Place": "lexington-fayette-ky"
+    },
+    {
+      "ID Place": "16000US0820000",
+      Place: "Denver, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.982965685605212,
+      "Slug Place": "denver-co"
+    },
+    {
+      "ID Place": "16000US0454050",
+      Place: "Peoria, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.954713006845708,
+      "Slug Place": "peoria-az"
+    },
+    {
+      "ID Place": "16000US3916000",
+      Place: "Cleveland, OH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.20681088914191,
+      "Slug Place": "cleveland-oh"
+    },
+    {
+      "ID Place": "16000US0644000",
+      Place: "Los Angeles, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.14561110005832,
+      "Slug Place": "los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US1238250",
+      Place: "Lakeland, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.798895157498826,
+      "Slug Place": "lakeland-fl"
+    },
+    {
+      "ID Place": "16000US2148006",
+      Place: "Louisville/Jefferson County metro government (balance), KY",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.725531723455354,
+      "Slug Place": "louisville-jefferson-county-metro-government-(balance)-ky"
+    },
+    {
+      "ID Place": "16000US3918000",
+      Place: "Columbus, OH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.976356665581303,
+      "Slug Place": "columbus-oh"
+    },
+    {
+      "ID Place": "16000US0681666",
+      Place: "Vallejo, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 33.32215024654356,
+      "Slug Place": "vallejo-ca"
+    },
+    {
+      "ID Place": "16000US0446000",
+      Place: "Mesa, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.765074037960044,
+      "Slug Place": "mesa-az"
+    },
+    {
+      "ID Place": "16000US3921000",
+      Place: "Dayton, OH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.761746685130035,
+      "Slug Place": "dayton-oh"
+    },
+    {
+      "ID Place": "16000US5335940",
+      Place: "Kirkland, WA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.075426613943456,
+      "Slug Place": "kirkland-wa"
+    },
+    {
+      "ID Place": "16000US4516000",
+      Place: "Columbia, SC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 14.36160256023187,
+      "Slug Place": "columbia-sc"
+    },
+    {
+      "ID Place": "16000US3977000",
+      Place: "Toledo, OH",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.385783569294077,
+      "Slug Place": "toledo-oh"
+    },
+    {
+      "ID Place": "16000US4837000",
+      Place: "Irving, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.85384715893315,
+      "Slug Place": "irving-tx"
+    },
+    {
+      "ID Place": "16000US2205000",
+      Place: "Baton Rouge, LA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.420160076807328,
+      "Slug Place": "baton-rouge-la"
+    },
+    {
+      "ID Place": "16000US4052500",
+      Place: "Norman, OK",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.739683014354068,
+      "Slug Place": "norman-ok"
+    },
+    {
+      "ID Place": "16000US1245000",
+      Place: "Miami, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.58772320779762,
+      "Slug Place": "miami-fl"
+    },
+    {
+      "ID Place": "16000US4055000",
+      Place: "Oklahoma City, OK",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.36018344230347,
+      "Slug Place": "oklahoma-city-ok"
+    },
+    {
+      "ID Place": "16000US0665042",
+      Place: "San Buenaventura (Ventura), CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.175506555423123,
+      "Slug Place": "san-buenaventura-(ventura)-ca"
+    },
+    {
+      "ID Place": "16000US0427820",
+      Place: "Glendale, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.42696099240602,
+      "Slug Place": "glendale-az"
+    },
+    {
+      "ID Place": "16000US2240735",
+      Place: "Lafayette, LA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.405876645036084,
+      "Slug Place": "lafayette-la"
+    },
+    {
+      "ID Place": "16000US4075000",
+      Place: "Tulsa, OK",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.71229247429631,
+      "Slug Place": "tulsa-ok"
+    },
+    {
+      "ID Place": "16000US2250115",
+      Place: "Metairie, LA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.01505459714415,
+      "Slug Place": "metairie-la"
+    },
+    {
+      "ID Place": "16000US0427400",
+      Place: "Gilbert, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.39861508722993,
+      "Slug Place": "gilbert-az"
+    },
+    {
+      "ID Place": "16000US0643000",
+      Place: "Long Beach, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 28.44000494125398,
+      "Slug Place": "long-beach-ca"
+    },
+    {
+      "ID Place": "16000US4105350",
+      Place: "Beaverton, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.63817897772793,
+      "Slug Place": "beaverton-or"
+    },
+    {
+      "ID Place": "16000US2255000",
+      Place: "New Orleans, LA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.151931964835263,
+      "Slug Place": "new-orleans-la"
+    },
+    {
+      "ID Place": "16000US7214290",
+      Place: "Carolina, PR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.29634057899998,
+      "Slug Place": "carolina-pr"
+    },
+    {
+      "ID Place": "16000US4513330",
+      Place: "Charleston, SC",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.541528771218108,
+      "Slug Place": "charleston-sc"
+    },
+    {
+      "ID Place": "16000US4123850",
+      Place: "Eugene, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 17.837584247389984,
+      "Slug Place": "eugene-or"
+    },
+    {
+      "ID Place": "16000US0659451",
+      Place: "Rancho Cucamonga, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.222632421793822,
+      "Slug Place": "rancho-cucamonga-ca"
+    },
+    {
+      "ID Place": "16000US4962470",
+      Place: "Provo, UT",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.71392910634049,
+      "Slug Place": "provo-ut"
+    },
+    {
+      "ID Place": "16000US4131250",
+      Place: "Gresham, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 29.701042960954855,
+      "Slug Place": "gresham-or"
+    },
+    {
+      "ID Place": "16000US1245025",
+      Place: "Miami Beach, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.11751662971175,
+      "Slug Place": "miami-beach-fl"
+    },
+    {
+      "ID Place": "16000US0412000",
+      Place: "Chandler, AZ",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.265343700379447,
+      "Slug Place": "chandler-az"
+    },
+    {
+      "ID Place": "16000US2270000",
+      Place: "Shreveport, LA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.378556711145997,
+      "Slug Place": "shreveport-la"
+    },
+    {
+      "ID Place": "16000US4134100",
+      Place: "Hillsboro, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.95428664389133,
+      "Slug Place": "hillsboro-or"
+    },
+    {
+      "ID Place": "16000US0669196",
+      Place: "Santa Maria, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.92790151139475,
+      "Slug Place": "santa-maria-ca"
+    },
+    {
+      "ID Place": "16000US0827425",
+      Place: "Fort Collins, CO",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 19.156640850899773,
+      "Slug Place": "fort-collins-co"
+    },
+    {
+      "ID Place": "16000US4835000",
+      Place: "Houston, TX",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 26.31598540388541,
+      "Slug Place": "houston-tx"
+    },
+    {
+      "ID Place": "16000US4159000",
+      Place: "Portland, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.1816441941648,
+      "Slug Place": "portland-or"
+    },
+    {
+      "ID Place": "16000US2360545",
+      Place: "Portland, ME",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.021629511677283,
+      "Slug Place": "portland-me"
+    },
+    {
+      "ID Place": "16000US0203000",
+      Place: "Anchorage, AK",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 18.860828882118227,
+      "Slug Place": "anchorage-ak"
+    },
+    {
+      "ID Place": "16000US4459000",
+      Place: "Providence, RI",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.10074070126825,
+      "Slug Place": "providence-ri"
+    },
+    {
+      "ID Place": "16000US4164900",
+      Place: "Salem, OR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.65216565091689,
+      "Slug Place": "salem-or"
+    },
+    {
+      "ID Place": "16000US1253000",
+      Place: "Orlando, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 24.741824204066766,
+      "Slug Place": "orlando-fl"
+    },
+    {
+      "ID Place": "16000US2404000",
+      Place: "Baltimore, MD",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.417365622267507,
+      "Slug Place": "baltimore-md"
+    },
+    {
+      "ID Place": "16000US4202000",
+      Place: "Allentown, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.92742177346796,
+      "Slug Place": "allentown-pa"
+    },
+    {
+      "ID Place": "16000US5167000",
+      Place: "Richmond, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 21.20666431331748,
+      "Slug Place": "richmond-va"
+    },
+    {
+      "ID Place": "16000US7276770",
+      Place: "San Juan, PR",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.283445165360774,
+      "Slug Place": "san-juan-pr"
+    },
+    {
+      "ID Place": "16000US4206088",
+      Place: "Bethlehem, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.096317280453256,
+      "Slug Place": "bethlehem-pa"
+    },
+    {
+      "ID Place": "16000US0659444",
+      Place: "Rancho Cordova, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.19702881152461,
+      "Slug Place": "rancho-cordova-ca"
+    },
+    {
+      "ID Place": "16000US4224000",
+      Place: "Erie, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 16.986340417768858,
+      "Slug Place": "erie-pa"
+    },
+    {
+      "ID Place": "16000US1255775",
+      Place: "Pembroke Pines, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.056003077604597,
+      "Slug Place": "pembroke-pines-fl"
+    },
+    {
+      "ID Place": "16000US0640130",
+      Place: "Lancaster, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.79114152612762,
+      "Slug Place": "lancaster-ca"
+    },
+    {
+      "ID Place": "16000US1258050",
+      Place: "Pompano Beach, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.93722880460442,
+      "Slug Place": "pompano-beach-fl"
+    },
+    {
+      "ID Place": "16000US4260000",
+      Place: "Philadelphia, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 31.96040838392827,
+      "Slug Place": "philadelphia-pa"
+    },
+    {
+      "ID Place": "16000US0665000",
+      Place: "San Bernardino, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.697106760289067,
+      "Slug Place": "san-bernardino-ca"
+    },
+    {
+      "ID Place": "16000US0150000",
+      Place: "Mobile, AL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 20.902700747528332,
+      "Slug Place": "mobile-al"
+    },
+    {
+      "ID Place": "16000US2430325",
+      Place: "Frederick, MD",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 30.455668032675657,
+      "Slug Place": "frederick-md"
+    },
+    {
+      "ID Place": "16000US4261000",
+      Place: "Pittsburgh, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.484680349267588,
+      "Slug Place": "pittsburgh-pa"
+    },
+    {
+      "ID Place": "16000US0636770",
+      Place: "Irvine, CA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 23.161003521849423,
+      "Slug Place": "irvine-ca"
+    },
+    {
+      "ID Place": "16000US5156000",
+      Place: "Newport News, VA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.82488233521133,
+      "Slug Place": "newport-news-va"
+    },
+    {
+      "ID Place": "16000US1263000",
+      Place: "St. Petersburg, FL",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 22.1250647836227,
+      "Slug Place": "st.-petersburg-fl"
+    },
+    {
+      "ID Place": "16000US4263624",
+      Place: "Reading, PA",
+      "ID Year": 2015,
+      Year: "2015",
+      "Average Commute Time": 25.427328323242158,
+      "Slug Place": "reading-pa"
+    },
+    {
+      "ID Place": "16000US4819000",
+      Place: "Dallas, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.403585453696657,
+      "Slug Place": "dallas-tx"
+    },
+    {
+      "ID Place": "16000US0668000",
+      Place: "San Jose, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.634389044509177,
+      "Slug Place": "san-jose-ca"
+    },
+    {
+      "ID Place": "16000US0827425",
+      Place: "Fort Collins, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.4445822390818,
+      "Slug Place": "fort-collins-co"
+    },
+    {
+      "ID Place": "16000US1714351",
+      Place: "Cicero, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.419147773832286,
+      "Slug Place": "cicero-il"
+    },
+    {
+      "ID Place": "16000US0465000",
+      Place: "Scottsdale, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.78234258405299,
+      "Slug Place": "scottsdale-az"
+    },
+    {
+      "ID Place": "16000US0203000",
+      Place: "Anchorage, AK",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.659403200955886,
+      "Slug Place": "anchorage-ak"
+    },
+    {
+      "ID Place": "16000US0608954",
+      Place: "Burbank, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.607877159595507,
+      "Slug Place": "burbank-la-county-ca"
+    },
+    {
+      "ID Place": "16000US4861796",
+      Place: "Richardson, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.427222728228124,
+      "Slug Place": "richardson-tx"
+    },
+    {
+      "ID Place": "16000US1723074",
+      Place: "Elgin, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.17873797601225,
+      "Slug Place": "elgin-il"
+    },
+    {
+      "ID Place": "16000US2743000",
+      Place: "Minneapolis, MN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.38575715285735,
+      "Slug Place": "minneapolis-mn"
+    },
+    {
+      "ID Place": "16000US0653896",
+      Place: "Ontario, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.61544966111176,
+      "Slug Place": "ontario-ca"
+    },
+    {
+      "ID Place": "16000US0832155",
+      Place: "Greeley, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.140740571637295,
+      "Slug Place": "greeley-co"
+    },
+    {
+      "ID Place": "16000US0668084",
+      Place: "San Leandro, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.377657779277758,
+      "Slug Place": "san-leandro-ca"
+    },
+    {
+      "ID Place": "16000US1724582",
+      Place: "Evanston, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.533361665958353,
+      "Slug Place": "evanston-il"
+    },
+    {
+      "ID Place": "16000US2754880",
+      Place: "Rochester, MN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.380311627171642,
+      "Slug Place": "rochester-mn"
+    },
+    {
+      "ID Place": "16000US5553000",
+      Place: "Milwaukee, WI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.643356510288818,
+      "Slug Place": "milwaukee-wi"
+    },
+    {
+      "ID Place": "16000US0836410",
+      Place: "Highlands Ranch, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.74869606448554,
+      "Slug Place": "highlands-ranch-co"
+    },
+    {
+      "ID Place": "16000US0611530",
+      Place: "Carson, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.16488380671339,
+      "Slug Place": "carson-ca"
+    },
+    {
+      "ID Place": "16000US4817000",
+      Place: "Corpus Christi, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.052113365609532,
+      "Slug Place": "corpus-christi-tx"
+    },
+    {
+      "ID Place": "16000US2758000",
+      Place: "St. Paul, MN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.93549821759687,
+      "Slug Place": "st.-paul-mn"
+    },
+    {
+      "ID Place": "16000US0620802",
+      Place: "East Los Angeles, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.24066118407594,
+      "Slug Place": "east-los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US1738570",
+      Place: "Joliet, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.6057327122895,
+      "Slug Place": "joliet-il"
+    },
+    {
+      "ID Place": "16000US5103000",
+      Place: "Arlington, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.247659669526488,
+      "Slug Place": "arlington-va"
+    },
+    {
+      "ID Place": "16000US0843000",
+      Place: "Lakewood, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.90414406211667,
+      "Slug Place": "lakewood-co"
+    },
+    {
+      "ID Place": "16000US5167000",
+      Place: "Richmond, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.796553352219075,
+      "Slug Place": "richmond-va"
+    },
+    {
+      "ID Place": "16000US2915670",
+      Place: "Columbia, MO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.146282661106405,
+      "Slug Place": "columbia-mo"
+    },
+    {
+      "ID Place": "16000US1751622",
+      Place: "Naperville, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.703625603700427,
+      "Slug Place": "naperville-il"
+    },
+    {
+      "ID Place": "16000US0668252",
+      Place: "San Mateo, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.731439768523604,
+      "Slug Place": "san-mateo-ca"
+    },
+    {
+      "ID Place": "16000US4815976",
+      Place: "College Station, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.15710966349944,
+      "Slug Place": "college-station-tx"
+    },
+    {
+      "ID Place": "16000US2938000",
+      Place: "Kansas City, MO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.56128739212251,
+      "Slug Place": "kansas-city-mo"
+    },
+    {
+      "ID Place": "16000US0633000",
+      Place: "Hayward, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.92840955237958,
+      "Slug Place": "hayward-ca"
+    },
+    {
+      "ID Place": "16000US4858016",
+      Place: "Plano, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.50941631886908,
+      "Slug Place": "plano-tx"
+    },
+    {
+      "ID Place": "16000US1759000",
+      Place: "Peoria, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.293714673750223,
+      "Slug Place": "peoria-il"
+    },
+    {
+      "ID Place": "16000US0653980",
+      Place: "Orange, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.55396322324805,
+      "Slug Place": "orange-ca"
+    },
+    {
+      "ID Place": "16000US2965000",
+      Place: "St. Louis, MO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.011995298672566,
+      "Slug Place": "st.-louis-mo"
+    },
+    {
+      "ID Place": "16000US4847892",
+      Place: "Mesquite, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.93316441827022,
+      "Slug Place": "mesquite-tx"
+    },
+    {
+      "ID Place": "16000US1765000",
+      Place: "Rockford, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.79571846752662,
+      "Slug Place": "rockford-il"
+    },
+    {
+      "ID Place": "16000US0600884",
+      Place: "Alhambra, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.91005621486571,
+      "Slug Place": "alhambra-ca"
+    },
+    {
+      "ID Place": "16000US4813024",
+      Place: "Carrollton, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.61852524518707,
+      "Slug Place": "carrollton-tx"
+    },
+    {
+      "ID Place": "16000US2970000",
+      Place: "Springfield, MO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.61442316575818,
+      "Slug Place": "springfield-mo"
+    },
+    {
+      "ID Place": "16000US0668378",
+      Place: "San Ramon, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 33.443819569905,
+      "Slug Place": "san-ramon-ca"
+    },
+    {
+      "ID Place": "16000US0137000",
+      Place: "Huntsville, AL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.5325930351056,
+      "Slug Place": "huntsville-al"
+    },
+    {
+      "ID Place": "16000US5322640",
+      Place: "Everett, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.523243851782837,
+      "Slug Place": "everett-wa"
+    },
+    {
+      "ID Place": "16000US1770122",
+      Place: "Skokie, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.922430324725134,
+      "Slug Place": "skokie-il"
+    },
+    {
+      "ID Place": "16000US3006550",
+      Place: "Billings, MT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.228929796065692,
+      "Slug Place": "billings-mt"
+    },
+    {
+      "ID Place": "16000US0654652",
+      Place: "Oxnard, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.56364779601483,
+      "Slug Place": "oxnard-ca"
+    },
+    {
+      "ID Place": "16000US3050200",
+      Place: "Missoula, MT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 14.291375604513702,
+      "Slug Place": "missoula-mt"
+    },
+    {
+      "ID Place": "16000US0669000",
+      Place: "Santa Ana, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.787065721769423,
+      "Slug Place": "santa-ana-ca"
+    },
+    {
+      "ID Place": "16000US5101000",
+      Place: "Alexandria, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.248826488285886,
+      "Slug Place": "alexandria-va"
+    },
+    {
+      "ID Place": "16000US3128000",
+      Place: "Lincoln, NE",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.92481337261608,
+      "Slug Place": "lincoln-ne"
+    },
+    {
+      "ID Place": "16000US1772000",
+      Place: "Springfield, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.797188572673942,
+      "Slug Place": "springfield-il"
+    },
+    {
+      "ID Place": "16000US0908000",
+      Place: "Bridgeport, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.33252148130219,
+      "Slug Place": "bridgeport-ct"
+    },
+    {
+      "ID Place": "16000US5539225",
+      Place: "Kenosha, WI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.147780136398538,
+      "Slug Place": "kenosha-wi"
+    },
+    {
+      "ID Place": "16000US0613014",
+      Place: "Chico, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.434855974902558,
+      "Slug Place": "chico-ca"
+    },
+    {
+      "ID Place": "16000US3137000",
+      Place: "Omaha, NE",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.334926974187464,
+      "Slug Place": "omaha-ne"
+    },
+    {
+      "ID Place": "16000US1779293",
+      Place: "Waukegan, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.82340334333476,
+      "Slug Place": "waukegan-il"
+    },
+    {
+      "ID Place": "16000US0636000",
+      Place: "Huntington Beach, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.005293229634443,
+      "Slug Place": "huntington-beach-ca"
+    },
+    {
+      "ID Place": "16000US0669070",
+      Place: "Santa Barbara, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 14.848645215918713,
+      "Slug Place": "santa-barbara-ca"
+    },
+    {
+      "ID Place": "16000US3223770",
+      Place: "Enterprise, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.17893042558899,
+      "Slug Place": "enterprise-nv"
+    },
+    {
+      "ID Place": "16000US0918430",
+      Place: "Danbury, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.077595776977276,
+      "Slug Place": "danbury-ct"
+    },
+    {
+      "ID Place": "16000US4810768",
+      Place: "Brownsville, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.223517905507073,
+      "Slug Place": "brownsville-tx"
+    },
+    {
+      "ID Place": "16000US3231900",
+      Place: "Henderson, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.21636222308589,
+      "Slug Place": "henderson-nv"
+    },
+    {
+      "ID Place": "16000US5566000",
+      Place: "Racine, WI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.449869891320986,
+      "Slug Place": "racine-wi"
+    },
+    {
+      "ID Place": "16000US0655156",
+      Place: "Palmdale, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 38.97232620102326,
+      "Slug Place": "palmdale-ca"
+    },
+    {
+      "ID Place": "16000US1825000",
+      Place: "Fort Wayne, IN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.676890794940604,
+      "Slug Place": "fort-wayne-in"
+    },
+    {
+      "ID Place": "16000US0937000",
+      Place: "Hartford, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.49725158562368,
+      "Slug Place": "hartford-ct"
+    },
+    {
+      "ID Place": "16000US3240000",
+      Place: "Las Vegas, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.364786903628946,
+      "Slug Place": "las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US0622020",
+      Place: "Elk Grove, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.87076931488873,
+      "Slug Place": "elk-grove-ca"
+    },
+    {
+      "ID Place": "16000US4983470",
+      Place: "West Valley City, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.8848264111422,
+      "Slug Place": "west-valley-city-ut"
+    },
+    {
+      "ID Place": "16000US0473000",
+      Place: "Tempe, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.036216679930956,
+      "Slug Place": "tempe-az"
+    },
+    {
+      "ID Place": "16000US0952000",
+      Place: "New Haven, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.69532121530284,
+      "Slug Place": "new-haven-ct"
+    },
+    {
+      "ID Place": "16000US3251800",
+      Place: "North Las Vegas, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.09237852854895,
+      "Slug Place": "north-las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US1836003",
+      Place: "Indianapolis city (balance), IN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.27712864806302,
+      "Slug Place": "indianapolis-city-(balance)-in"
+    },
+    {
+      "ID Place": "16000US0669084",
+      Place: "Santa Clara, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.477247712192206,
+      "Slug Place": "santa-clara-ca"
+    },
+    {
+      "ID Place": "16000US5363000",
+      Place: "Seattle, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.88127662127302,
+      "Slug Place": "seattle-wa"
+    },
+    {
+      "ID Place": "16000US0602000",
+      Place: "Anaheim, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.087885913951844,
+      "Slug Place": "anaheim-ca"
+    },
+    {
+      "ID Place": "16000US3254600",
+      Place: "Paradise, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.415604665545867,
+      "Slug Place": "paradise-nv"
+    },
+    {
+      "ID Place": "16000US4845000",
+      Place: "Lubbock, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.221763795771016,
+      "Slug Place": "lubbock-tx"
+    },
+    {
+      "ID Place": "16000US1871000",
+      Place: "South Bend, IN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.306957101578128,
+      "Slug Place": "south-bend-in"
+    },
+    {
+      "ID Place": "16000US4982950",
+      Place: "West Jordan, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.528676076469537,
+      "Slug Place": "west-jordan-ut"
+    },
+    {
+      "ID Place": "16000US4805000",
+      Place: "Austin, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.664899033178415,
+      "Slug Place": "austin-tx"
+    },
+    {
+      "ID Place": "16000US3260600",
+      Place: "Reno, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.514812626231446,
+      "Slug Place": "reno-nv"
+    },
+    {
+      "ID Place": "16000US0955990",
+      Place: "Norwalk, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.09898563696032,
+      "Slug Place": "norwalk-ct"
+    },
+    {
+      "ID Place": "16000US0655282",
+      Place: "Palo Alto, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.336610418195157,
+      "Slug Place": "palo-alto-ca"
+    },
+    {
+      "ID Place": "16000US1912000",
+      Place: "Cedar Rapids, IA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.296021478410953,
+      "Slug Place": "cedar-rapids-ia"
+    },
+    {
+      "ID Place": "16000US0613392",
+      Place: "Chula Vista, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.82327841859724,
+      "Slug Place": "chula-vista-ca"
+    },
+    {
+      "ID Place": "16000US0669088",
+      Place: "Santa Clarita, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.796947170900694,
+      "Slug Place": "santa-clarita-ca"
+    },
+    {
+      "ID Place": "16000US1919000",
+      Place: "Davenport, IA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.977676354886757,
+      "Slug Place": "davenport-ia"
+    },
+    {
+      "ID Place": "16000US3268585",
+      Place: "Spring Valley, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.11662686942315,
+      "Slug Place": "spring-valley-nv"
+    },
+    {
+      "ID Place": "16000US0973000",
+      Place: "Stamford, CT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.822267328006404,
+      "Slug Place": "stamford-ct"
+    },
+    {
+      "ID Place": "16000US5374060",
+      Place: "Vancouver, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.464256660565386,
+      "Slug Place": "vancouver-wa"
+    },
+    {
+      "ID Place": "16000US1921000",
+      Place: "Des Moines, IA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.57837950097412,
+      "Slug Place": "des-moines-ia"
+    },
+    {
+      "ID Place": "16000US5305280",
+      Place: "Bellingham, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.929911762694088,
+      "Slug Place": "bellingham-wa"
+    },
+    {
+      "ID Place": "16000US3271400",
+      Place: "Sunrise Manor, NV",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.48331549126609,
+      "Slug Place": "sunrise-manor-nv"
+    },
+    {
+      "ID Place": "16000US0656000",
+      Place: "Pasadena, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.202791899559028,
+      "Slug Place": "pasadena-ca"
+    },
+    {
+      "ID Place": "16000US0622230",
+      Place: "El Monte, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.29777570510351,
+      "Slug Place": "el-monte-ca"
+    },
+    {
+      "ID Place": "16000US0636770",
+      Place: "Irvine, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.182784783992567,
+      "Slug Place": "irvine-ca"
+    },
+    {
+      "ID Place": "16000US0669196",
+      Place: "Santa Maria, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.658647002543578,
+      "Slug Place": "santa-maria-ca"
+    },
+    {
+      "ID Place": "16000US1150000",
+      Place: "Washington, DC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.84617649287884,
+      "Slug Place": "washington-dc"
+    },
+    {
+      "ID Place": "16000US0446000",
+      Place: "Mesa, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.70638796639969,
+      "Slug Place": "mesa-az"
+    },
+    {
+      "ID Place": "16000US3403580",
+      Place: "Bayonne, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.470369291516977,
+      "Slug Place": "bayonne-nj"
+    },
+    {
+      "ID Place": "16000US2036000",
+      Place: "Kansas City, KS",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.864574931440554,
+      "Slug Place": "kansas-city-ks"
+    },
+    {
+      "ID Place": "16000US0423620",
+      Place: "Flagstaff, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 14.91542302513465,
+      "Slug Place": "flagstaff-az"
+    },
+    {
+      "ID Place": "16000US0622804",
+      Place: "Escondido, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.15098672513927,
+      "Slug Place": "escondido-ca"
+    },
+    {
+      "ID Place": "16000US4804000",
+      Place: "Arlington, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.507340740008132,
+      "Slug Place": "arlington-tx"
+    },
+    {
+      "ID Place": "16000US3413690",
+      Place: "Clifton, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.786499037263564,
+      "Slug Place": "clifton-nj"
+    },
+    {
+      "ID Place": "16000US4967440",
+      Place: "Sandy, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.784267947739416,
+      "Slug Place": "sandy-ut"
+    },
+    {
+      "ID Place": "16000US3419390",
+      Place: "East Orange, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 35.065373100390346,
+      "Slug Place": "east-orange-nj"
+    },
+    {
+      "ID Place": "16000US1212875",
+      Place: "Clearwater, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.972750662716358,
+      "Slug Place": "clearwater-fl"
+    },
+    {
+      "ID Place": "16000US0670000",
+      Place: "Santa Monica, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.68322882134441,
+      "Slug Place": "santa-monica-ca"
+    },
+    {
+      "ID Place": "16000US3421000",
+      Place: "Elizabeth, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.96154170247906,
+      "Slug Place": "elizabeth-nj"
+    },
+    {
+      "ID Place": "16000US0657792",
+      Place: "Pleasanton, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.848798451696144,
+      "Slug Place": "pleasanton-ca"
+    },
+    {
+      "ID Place": "16000US2071000",
+      Place: "Topeka, KS",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.612368979927382,
+      "Slug Place": "topeka-ks"
+    },
+    {
+      "ID Place": "16000US7214290",
+      Place: "Carolina, PR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.75711996503751,
+      "Slug Place": "carolina-pr"
+    },
+    {
+      "ID Place": "16000US4803000",
+      Place: "Amarillo, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.66637940763083,
+      "Slug Place": "amarillo-tx"
+    },
+    {
+      "ID Place": "16000US3436000",
+      Place: "Jersey City, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 35.85052623432905,
+      "Slug Place": "jersey-city-nj"
+    },
+    {
+      "ID Place": "16000US5357745",
+      Place: "Renton, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.5765134529148,
+      "Slug Place": "renton-wa"
+    },
+    {
+      "ID Place": "16000US4841464",
+      Place: "Laredo, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.84618730374268,
+      "Slug Place": "laredo-tx"
+    },
+    {
+      "ID Place": "16000US2079000",
+      Place: "Wichita, KS",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.69791375484195,
+      "Slug Place": "wichita-ks"
+    },
+    {
+      "ID Place": "16000US4801000",
+      Place: "Abilene, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 14.645347461175742,
+      "Slug Place": "abilene-tx"
+    },
+    {
+      "ID Place": "16000US3451000",
+      Place: "Newark, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 35.007929432338365,
+      "Slug Place": "newark-nj"
+    },
+    {
+      "ID Place": "16000US1224000",
+      Place: "Fort Lauderdale, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.285392784302694,
+      "Slug Place": "fort-lauderdale-fl"
+    },
+    {
+      "ID Place": "16000US5157000",
+      Place: "Norfolk, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.682891887932016,
+      "Slug Place": "norfolk-va"
+    },
+    {
+      "ID Place": "16000US0670098",
+      Place: "Santa Rosa, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.057415863351938,
+      "Slug Place": "santa-rosa-ca"
+    },
+    {
+      "ID Place": "16000US0640130",
+      Place: "Lancaster, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.059598249179302,
+      "Slug Place": "lancaster-ca"
+    },
+    {
+      "ID Place": "16000US3456550",
+      Place: "Passaic, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.51135425268373,
+      "Slug Place": "passaic-nj"
+    },
+    {
+      "ID Place": "16000US2146027",
+      Place: "Lexington-Fayette, KY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.763949461262186,
+      "Slug Place": "lexington-fayette-ky"
+    },
+    {
+      "ID Place": "16000US0427400",
+      Place: "Gilbert, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.454671162973273,
+      "Slug Place": "gilbert-az"
+    },
+    {
+      "ID Place": "16000US1225175",
+      Place: "Gainesville, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.304895704863533,
+      "Slug Place": "gainesville-fl"
+    },
+    {
+      "ID Place": "16000US0658072",
+      Place: "Pomona, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.23642961544277,
+      "Slug Place": "pomona-ca"
+    },
+    {
+      "ID Place": "16000US3457000",
+      Place: "Paterson, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.231961815212905,
+      "Slug Place": "paterson-nj"
+    },
+    {
+      "ID Place": "16000US0602252",
+      Place: "Antioch, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 40.32100661892606,
+      "Slug Place": "antioch-ca"
+    },
+    {
+      "ID Place": "16000US2148006",
+      Place: "Louisville/Jefferson County metro government (balance), KY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.697633691378655,
+      "Slug Place": "louisville-jefferson-county-metro-government-(balance)-ky"
+    },
+    {
+      "ID Place": "16000US0672016",
+      Place: "Simi Valley, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.035089127991007,
+      "Slug Place": "simi-valley-ca"
+    },
+    {
+      "ID Place": "16000US0615044",
+      Place: "Compton, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.514295136862934,
+      "Slug Place": "compton-ca"
+    },
+    {
+      "ID Place": "16000US1230000",
+      Place: "Hialeah, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.3495104299702,
+      "Slug Place": "hialeah-fl"
+    },
+    {
+      "ID Place": "16000US4752006",
+      Place: "Nashville-Davidson metropolitan government (balance), TN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.760686728977607,
+      "Slug Place": "nashville-davidson-metropolitan-government-(balance)-tn"
+    },
+    {
+      "ID Place": "16000US3474630",
+      Place: "Union City, NJ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.28926368711818,
+      "Slug Place": "union-city-nj"
+    },
+    {
+      "ID Place": "16000US0673080",
+      Place: "South Gate, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.558814254178493,
+      "Slug Place": "south-gate-ca"
+    },
+    {
+      "ID Place": "16000US2205000",
+      Place: "Baton Rouge, LA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.030073716485095,
+      "Slug Place": "baton-rouge-la"
+    },
+    {
+      "ID Place": "16000US0641992",
+      Place: "Livermore, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.470110260402226,
+      "Slug Place": "livermore-ca"
+    },
+    {
+      "ID Place": "16000US0623182",
+      Place: "Fairfield, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.09619562989382,
+      "Slug Place": "fairfield-ca"
+    },
+    {
+      "ID Place": "16000US3502000",
+      Place: "Albuquerque, NM",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.242311258714942,
+      "Slug Place": "albuquerque-nm"
+    },
+    {
+      "ID Place": "16000US4967000",
+      Place: "Salt Lake City, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.504900507834886,
+      "Slug Place": "salt-lake-city-ut"
+    },
+    {
+      "ID Place": "16000US1232000",
+      Place: "Hollywood, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.252939027854815,
+      "Slug Place": "hollywood-fl"
+    },
+    {
+      "ID Place": "16000US4837000",
+      Place: "Irving, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.44375625409751,
+      "Slug Place": "irving-tx"
+    },
+    {
+      "ID Place": "16000US3570500",
+      Place: "Santa Fe, NM",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.323974847223454,
+      "Slug Place": "santa-fe-nm"
+    },
+    {
+      "ID Place": "16000US3601000",
+      Place: "Albany, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.422199928940163,
+      "Slug Place": "albany-ny"
+    },
+    {
+      "ID Place": "16000US0477000",
+      Place: "Tucson, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.45005066204125,
+      "Slug Place": "tucson-az"
+    },
+    {
+      "ID Place": "16000US0673262",
+      Place: "South San Francisco, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.837208678627942,
+      "Slug Place": "south-san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US3611000",
+      Place: "Buffalo, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.463945300161647,
+      "Slug Place": "buffalo-ny"
+    },
+    {
+      "ID Place": "16000US2255000",
+      Place: "New Orleans, LA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.1905672590326,
+      "Slug Place": "new-orleans-la"
+    },
+    {
+      "ID Place": "16000US0659451",
+      Place: "Rancho Cucamonga, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 33.17382800487127,
+      "Slug Place": "rancho-cucamonga-ca"
+    },
+    {
+      "ID Place": "16000US0643000",
+      Place: "Long Beach, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.295435607814092,
+      "Slug Place": "long-beach-ca"
+    },
+    {
+      "ID Place": "16000US1235000",
+      Place: "Jacksonville, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.890224237778696,
+      "Slug Place": "jacksonville-fl"
+    },
+    {
+      "ID Place": "16000US3649121",
+      Place: "Mount Vernon, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 34.904130257119505,
+      "Slug Place": "mount-vernon-ny"
+    },
+    {
+      "ID Place": "16000US0602553",
+      Place: "Arden-Arcade, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.985524639952974,
+      "Slug Place": "arden-arcade-ca"
+    },
+    {
+      "ID Place": "16000US0675000",
+      Place: "Stockton, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.588575988237086,
+      "Slug Place": "stockton-ca"
+    },
+    {
+      "ID Place": "16000US0616000",
+      Place: "Concord, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.090084857871133,
+      "Slug Place": "concord-ca"
+    },
+    {
+      "ID Place": "16000US4748000",
+      Place: "Memphis, TN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.989543672617536,
+      "Slug Place": "memphis-tn"
+    },
+    {
+      "ID Place": "16000US3650617",
+      Place: "New Rochelle, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.796028518351157,
+      "Slug Place": "new-rochelle-ny"
+    },
+    {
+      "ID Place": "16000US2431175",
+      Place: "Gaithersburg, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.78361886208675,
+      "Slug Place": "gaithersburg-md"
+    },
+    {
+      "ID Place": "16000US0660102",
+      Place: "Redwood City, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.760907950374055,
+      "Slug Place": "redwood-city-ca"
+    },
+    {
+      "ID Place": "16000US2360545",
+      Place: "Portland, ME",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.668029076234575,
+      "Slug Place": "portland-me"
+    },
+    {
+      "ID Place": "16000US1245000",
+      Place: "Miami, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.714631326331336,
+      "Slug Place": "miami-fl"
+    },
+    {
+      "ID Place": "16000US3651000",
+      Place: "New York, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 38.55855992988296,
+      "Slug Place": "new-york-ny"
+    },
+    {
+      "ID Place": "16000US5156000",
+      Place: "Newport News, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.381397483544532,
+      "Slug Place": "newport-news-va"
+    },
+    {
+      "ID Place": "16000US4835000",
+      Place: "Houston, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.64080065227154,
+      "Slug Place": "houston-tx"
+    },
+    {
+      "ID Place": "16000US2404000",
+      Place: "Baltimore, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.925769824961378,
+      "Slug Place": "baltimore-md"
+    },
+    {
+      "ID Place": "16000US0677000",
+      Place: "Sunnyvale, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.199357788178947,
+      "Slug Place": "sunnyvale-ca"
+    },
+    {
+      "ID Place": "16000US3663000",
+      Place: "Rochester, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.035747771698492,
+      "Slug Place": "rochester-ny"
+    },
+    {
+      "ID Place": "16000US0624680",
+      Place: "Fontana, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.73288729367762,
+      "Slug Place": "fontana-ca"
+    },
+    {
+      "ID Place": "16000US0644000",
+      Place: "Los Angeles, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.49852205395642,
+      "Slug Place": "los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US1245025",
+      Place: "Miami Beach, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.17674795707184,
+      "Slug Place": "miami-beach-fl"
+    },
+    {
+      "ID Place": "16000US2407125",
+      Place: "Bethesda, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.0670111416115,
+      "Slug Place": "bethesda-md"
+    },
+    {
+      "ID Place": "16000US4740000",
+      Place: "Knoxville, TN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.72091587977535,
+      "Slug Place": "knoxville-tn"
+    },
+    {
+      "ID Place": "16000US3673000",
+      Place: "Syracuse, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.041444208345983,
+      "Slug Place": "syracuse-ny"
+    },
+    {
+      "ID Place": "16000US0150000",
+      Place: "Mobile, AL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.851755897249895,
+      "Slug Place": "mobile-al"
+    },
+    {
+      "ID Place": "16000US4830464",
+      Place: "Grand Prairie, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.511572073369827,
+      "Slug Place": "grand-prairie-tx"
+    },
+    {
+      "ID Place": "16000US2419125",
+      Place: "Columbia, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.8484767121326,
+      "Slug Place": "columbia-md"
+    },
+    {
+      "ID Place": "16000US0151000",
+      Place: "Montgomery, AL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.720468396904746,
+      "Slug Place": "montgomery-al"
+    },
+    {
+      "ID Place": "16000US3684000",
+      Place: "Yonkers, NY",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 34.76084695561735,
+      "Slug Place": "yonkers-ny"
+    },
+    {
+      "ID Place": "16000US0680000",
+      Place: "Torrance, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.453010675740803,
+      "Slug Place": "torrance-ca"
+    },
+    {
+      "ID Place": "16000US4962470",
+      Place: "Provo, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.45484556751992,
+      "Slug Place": "provo-ut"
+    },
+    {
+      "ID Place": "16000US1253000",
+      Place: "Orlando, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.421068134141787,
+      "Slug Place": "orlando-fl"
+    },
+    {
+      "ID Place": "16000US0107000",
+      Place: "Birmingham, AL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.31053244343005,
+      "Slug Place": "birmingham-al"
+    },
+    {
+      "ID Place": "16000US5531000",
+      Place: "Green Bay, WI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.13715835011264,
+      "Slug Place": "green-bay-wi"
+    },
+    {
+      "ID Place": "16000US0660620",
+      Place: "Richmond, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.32730787422625,
+      "Slug Place": "richmond-ca"
+    },
+    {
+      "ID Place": "16000US4715160",
+      Place: "Clarksville, TN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.790359956743394,
+      "Slug Place": "clarksville-tn"
+    },
+    {
+      "ID Place": "16000US3712000",
+      Place: "Charlotte, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.90084645059281,
+      "Slug Place": "charlotte-nc"
+    },
+    {
+      "ID Place": "16000US0644574",
+      Place: "Lynwood, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.825407033815118,
+      "Slug Place": "lynwood-ca"
+    },
+    {
+      "ID Place": "16000US2432025",
+      Place: "Germantown, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.72840087295135,
+      "Slug Place": "germantown-md"
+    },
+    {
+      "ID Place": "16000US0680238",
+      Place: "Tracy, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 39.53890759446315,
+      "Slug Place": "tracy-ca"
+    },
+    {
+      "ID Place": "16000US1258050",
+      Place: "Pompano Beach, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.87971078001753,
+      "Slug Place": "pompano-beach-fl"
+    },
+    {
+      "ID Place": "16000US3719000",
+      Place: "Durham, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.65502786488375,
+      "Slug Place": "durham-nc"
+    },
+    {
+      "ID Place": "16000US5370000",
+      Place: "Tacoma, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.28994269866841,
+      "Slug Place": "tacoma-wa"
+    },
+    {
+      "ID Place": "16000US2467675",
+      Place: "Rockville, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.22737084472586,
+      "Slug Place": "rockville-md"
+    },
+    {
+      "ID Place": "16000US0626000",
+      Place: "Fremont, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.950520379091806,
+      "Slug Place": "fremont-ca"
+    },
+    {
+      "ID Place": "16000US0681204",
+      Place: "Union City, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.506598076492956,
+      "Slug Place": "union-city-ca"
+    },
+    {
+      "ID Place": "16000US3722920",
+      Place: "Fayetteville, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.270828702380573,
+      "Slug Place": "fayetteville-nc"
+    },
+    {
+      "ID Place": "16000US1263000",
+      Place: "St. Petersburg, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.027445754029404,
+      "Slug Place": "st.-petersburg-fl"
+    },
+    {
+      "ID Place": "16000US2472450",
+      Place: "Silver Spring, MD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 32.68191366329156,
+      "Slug Place": "silver-spring-md"
+    },
+    {
+      "ID Place": "16000US0647766",
+      Place: "Milpitas, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.350069541029207,
+      "Slug Place": "milpitas-ca"
+    },
+    {
+      "ID Place": "16000US0662000",
+      Place: "Riverside, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.609967810770733,
+      "Slug Place": "riverside-ca"
+    },
+    {
+      "ID Place": "16000US3728000",
+      Place: "Greensboro, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.11668310271503,
+      "Slug Place": "greensboro-nc"
+    },
+    {
+      "ID Place": "16000US0616350",
+      Place: "Corona, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 34.78751972536752,
+      "Slug Place": "corona-ca"
+    },
+    {
+      "ID Place": "16000US4829000",
+      Place: "Garland, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.703138846135907,
+      "Slug Place": "garland-tx"
+    },
+    {
+      "ID Place": "16000US2507000",
+      Place: "Boston, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.74261898136911,
+      "Slug Place": "boston-ma"
+    },
+    {
+      "ID Place": "16000US4714000",
+      Place: "Chattanooga, TN",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.782153052536685,
+      "Slug Place": "chattanooga-tn"
+    },
+    {
+      "ID Place": "16000US3755000",
+      Place: "Raleigh, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.72379263719162,
+      "Slug Place": "raleigh-nc"
+    },
+    {
+      "ID Place": "16000US5135000",
+      Place: "Hampton, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.7082786810237,
+      "Slug Place": "hampton-va"
+    },
+    {
+      "ID Place": "16000US1270600",
+      Place: "Tallahassee, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.45889195253458,
+      "Slug Place": "tallahassee-fl"
+    },
+    {
+      "ID Place": "16000US0681666",
+      Place: "Vallejo, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.95614979430197,
+      "Slug Place": "vallejo-ca"
+    },
+    {
+      "ID Place": "16000US0648354",
+      Place: "Modesto, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.452203846801954,
+      "Slug Place": "modesto-ca"
+    },
+    {
+      "ID Place": "16000US3774440",
+      Place: "Wilmington, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.035102591605828,
+      "Slug Place": "wilmington-nc"
+    },
+    {
+      "ID Place": "16000US2509000",
+      Place: "Brockton, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.337179606240714,
+      "Slug Place": "brockton-ma"
+    },
+    {
+      "ID Place": "16000US0412000",
+      Place: "Chandler, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.395051615203162,
+      "Slug Place": "chandler-az"
+    },
+    {
+      "ID Place": "16000US5303180",
+      Place: "Auburn, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.42411194833154,
+      "Slug Place": "auburn-wa"
+    },
+    {
+      "ID Place": "16000US3775000",
+      Place: "Winston-Salem, NC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.022723350399815,
+      "Slug Place": "winston-salem-nc"
+    },
+    {
+      "ID Place": "16000US1271000",
+      Place: "Tampa, FL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.75882978913138,
+      "Slug Place": "tampa-fl"
+    },
+    {
+      "ID Place": "16000US0603526",
+      Place: "Bakersfield, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.506830546310034,
+      "Slug Place": "bakersfield-ca"
+    },
+    {
+      "ID Place": "16000US2511000",
+      Place: "Cambridge, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.148920920602055,
+      "Slug Place": "cambridge-ma"
+    },
+    {
+      "ID Place": "16000US0682954",
+      Place: "Visalia, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.170471841704718,
+      "Slug Place": "visalia-ca"
+    },
+    {
+      "ID Place": "16000US0541000",
+      Place: "Little Rock, AR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.366319143402116,
+      "Slug Place": "little-rock-ar"
+    },
+    {
+      "ID Place": "16000US4659020",
+      Place: "Sioux Falls, SD",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.24904873599166,
+      "Slug Place": "sioux-falls-sd"
+    },
+    {
+      "ID Place": "16000US3901000",
+      Place: "Akron, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.834356381001722,
+      "Slug Place": "akron-oh"
+    },
+    {
+      "ID Place": "16000US0682996",
+      Place: "Vista, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.472819494982907,
+      "Slug Place": "vista-ca"
+    },
+    {
+      "ID Place": "16000US0664000",
+      Place: "Sacramento, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.230356057023172,
+      "Slug Place": "sacramento-ca"
+    },
+    {
+      "ID Place": "16000US4550875",
+      Place: "North Charleston, SC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.860350560321827,
+      "Slug Place": "north-charleston-sc"
+    },
+    {
+      "ID Place": "16000US3915000",
+      Place: "Cincinnati, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.149970669696227,
+      "Slug Place": "cincinnati-oh"
+    },
+    {
+      "ID Place": "16000US1303440",
+      Place: "Athens-Clarke County unified government (balance), GA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.48057983625361,
+      "Slug Place": "athens-clarke-county-unified-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US0649270",
+      Place: "Moreno Valley, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.718910717959268,
+      "Slug Place": "moreno-valley-ca"
+    },
+    {
+      "ID Place": "16000US4827000",
+      Place: "Fort Worth, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.675096442348906,
+      "Slug Place": "fort-worth-tx"
+    },
+    {
+      "ID Place": "16000US2534550",
+      Place: "Lawrence, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.554434842923616,
+      "Slug Place": "lawrence-ma"
+    },
+    {
+      "ID Place": "16000US3916000",
+      Place: "Cleveland, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.48399991672045,
+      "Slug Place": "cleveland-oh"
+    },
+    {
+      "ID Place": "16000US0684200",
+      Place: "West Covina, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 33.55756365875932,
+      "Slug Place": "west-covina-ca"
+    },
+    {
+      "ID Place": "16000US0627000",
+      Place: "Fresno, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.114192662470582,
+      "Slug Place": "fresno-ca"
+    },
+    {
+      "ID Place": "16000US4957300",
+      Place: "Orem, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.337340345604808,
+      "Slug Place": "orem-ut"
+    },
+    {
+      "ID Place": "16000US1304000",
+      Place: "Atlanta, GA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.977927000773022,
+      "Slug Place": "atlanta-ga"
+    },
+    {
+      "ID Place": "16000US3918000",
+      Place: "Columbus, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.5804249919826,
+      "Slug Place": "columbus-oh"
+    },
+    {
+      "ID Place": "16000US2537000",
+      Place: "Lowell, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.959875079063885,
+      "Slug Place": "lowell-ma"
+    },
+    {
+      "ID Place": "16000US0455000",
+      Place: "Phoenix, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.749475663556808,
+      "Slug Place": "phoenix-az"
+    },
+    {
+      "ID Place": "16000US0684550",
+      Place: "Westminster, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.938065909822125,
+      "Slug Place": "westminster-ca"
+    },
+    {
+      "ID Place": "16000US3921000",
+      Place: "Dayton, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.85626306570993,
+      "Slug Place": "dayton-oh"
+    },
+    {
+      "ID Place": "16000US0616532",
+      Place: "Costa Mesa, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.22915638875185,
+      "Slug Place": "costa-mesa-ca"
+    },
+    {
+      "ID Place": "16000US0685292",
+      Place: "Whittier, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.759178433889602,
+      "Slug Place": "whittier-ca"
+    },
+    {
+      "ID Place": "16000US2537490",
+      Place: "Lynn, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.360630596089223,
+      "Slug Place": "lynn-ma"
+    },
+    {
+      "ID Place": "16000US3977000",
+      Place: "Toledo, OH",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.238846590812745,
+      "Slug Place": "toledo-oh"
+    },
+    {
+      "ID Place": "16000US0664224",
+      Place: "Salinas, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.056018923859117,
+      "Slug Place": "salinas-ca"
+    },
+    {
+      "ID Place": "16000US0427820",
+      Place: "Glendale, AZ",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.044667930534576,
+      "Slug Place": "glendale-az"
+    },
+    {
+      "ID Place": "16000US0649670",
+      Place: "Mountain View, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.252457745033187,
+      "Slug Place": "mountain-view-ca"
+    },
+    {
+      "ID Place": "16000US2545000",
+      Place: "New Bedford, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.956313930129998,
+      "Slug Place": "new-bedford-ma"
+    },
+    {
+      "ID Place": "16000US1319000",
+      Place: "Columbus, GA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.300459468329503,
+      "Slug Place": "columbus-ga"
+    },
+    {
+      "ID Place": "16000US4516000",
+      Place: "Columbia, SC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 14.764947973287777,
+      "Slug Place": "columbia-sc"
+    },
+    {
+      "ID Place": "16000US4055000",
+      Place: "Oklahoma City, OK",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.29399145255832,
+      "Slug Place": "oklahoma-city-ok"
+    },
+    {
+      "ID Place": "16000US0121184",
+      Place: "Dothan, AL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.205671213208902,
+      "Slug Place": "dothan-al"
+    },
+    {
+      "ID Place": "16000US0628000",
+      Place: "Fullerton, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 27.688261395724084,
+      "Slug Place": "fullerton-ca"
+    },
+    {
+      "ID Place": "16000US0665000",
+      Place: "San Bernardino, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.762906549342837,
+      "Slug Place": "san-bernardino-ca"
+    },
+    {
+      "ID Place": "16000US2545560",
+      Place: "Newton, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.665306870788836,
+      "Slug Place": "newton-ma"
+    },
+    {
+      "ID Place": "16000US4075000",
+      Place: "Tulsa, OK",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.46687839339245,
+      "Slug Place": "tulsa-ok"
+    },
+    {
+      "ID Place": "16000US1349008",
+      Place: "Macon-Bibb County, GA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.240360585505176,
+      "Slug Place": "macon-bibb-county-ga"
+    },
+    {
+      "ID Place": "16000US0804000",
+      Place: "Aurora, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.704959667941317,
+      "Slug Place": "aurora-co"
+    },
+    {
+      "ID Place": "16000US7276770",
+      Place: "San Juan, PR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.50605798530565,
+      "Slug Place": "san-juan-pr"
+    },
+    {
+      "ID Place": "16000US4824000",
+      Place: "El Paso, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.09020741184556,
+      "Slug Place": "el-paso-tx"
+    },
+    {
+      "ID Place": "16000US4105350",
+      Place: "Beaverton, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.590302582419838,
+      "Slug Place": "beaverton-or"
+    },
+    {
+      "ID Place": "16000US2555745",
+      Place: "Quincy, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 35.086230821076,
+      "Slug Place": "quincy-ma"
+    },
+    {
+      "ID Place": "16000US4955980",
+      Place: "Ogden, UT",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.142673556263553,
+      "Slug Place": "ogden-ut"
+    },
+    {
+      "ID Place": "16000US0617918",
+      Place: "Daly City, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.73318740342874,
+      "Slug Place": "daly-city-ca"
+    },
+    {
+      "ID Place": "16000US4876000",
+      Place: "Waco, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.395175487882534,
+      "Slug Place": "waco-tx"
+    },
+    {
+      "ID Place": "16000US4123850",
+      Place: "Eugene, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.960156977517627,
+      "Slug Place": "eugene-or"
+    },
+    {
+      "ID Place": "16000US1369000",
+      Place: "Savannah, GA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.257003262564087,
+      "Slug Place": "savannah-ga"
+    },
+    {
+      "ID Place": "16000US2562535",
+      Place: "Somerville, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.5999124883152,
+      "Slug Place": "somerville-ma"
+    },
+    {
+      "ID Place": "16000US5548000",
+      Place: "Madison, WI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.193609778518283,
+      "Slug Place": "madison-wi"
+    },
+    {
+      "ID Place": "16000US4513330",
+      Place: "Charleston, SC",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.89985304602133,
+      "Slug Place": "charleston-sc"
+    },
+    {
+      "ID Place": "16000US4131250",
+      Place: "Gresham, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.032007286900527,
+      "Slug Place": "gresham-or"
+    },
+    {
+      "ID Place": "16000US5182000",
+      Place: "Virginia Beach, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.998227711452724,
+      "Slug Place": "virginia-beach-va"
+    },
+    {
+      "ID Place": "16000US0807850",
+      Place: "Boulder, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 16.11417112299465,
+      "Slug Place": "boulder-co"
+    },
+    {
+      "ID Place": "16000US0665042",
+      Place: "San Buenaventura (Ventura), CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.47752578927868,
+      "Slug Place": "san-buenaventura-(ventura)-ca"
+    },
+    {
+      "ID Place": "16000US1571550",
+      Place: "Urban Honolulu, HI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.85927815645001,
+      "Slug Place": "urban-honolulu-hi"
+    },
+    {
+      "ID Place": "16000US4134100",
+      Place: "Hillsboro, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.18644822907596,
+      "Slug Place": "hillsboro-or"
+    },
+    {
+      "ID Place": "16000US0606000",
+      Place: "Berkeley, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.749051547109396,
+      "Slug Place": "berkeley-ca"
+    },
+    {
+      "ID Place": "16000US0652526",
+      Place: "Norwalk, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.36260103606055,
+      "Slug Place": "norwalk-ca"
+    },
+    {
+      "ID Place": "16000US2582000",
+      Place: "Worcester, MA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.41930766709528,
+      "Slug Place": "worcester-ma"
+    },
+    {
+      "ID Place": "16000US0629000",
+      Place: "Garden Grove, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.607710474245227,
+      "Slug Place": "garden-grove-ca"
+    },
+    {
+      "ID Place": "16000US4159000",
+      Place: "Portland, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.290401863108187,
+      "Slug Place": "portland-or"
+    },
+    {
+      "ID Place": "16000US0812815",
+      Place: "Centennial, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.759443375383082,
+      "Slug Place": "centennial-co"
+    },
+    {
+      "ID Place": "16000US1608830",
+      Place: "Boise City, ID",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.568421444457886,
+      "Slug Place": "boise-city-id"
+    },
+    {
+      "ID Place": "16000US4819972",
+      Place: "Denton, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.979726366283018,
+      "Slug Place": "denton-tx"
+    },
+    {
+      "ID Place": "16000US2603000",
+      Place: "Ann Arbor, MI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.67312709653373,
+      "Slug Place": "ann-arbor-mi"
+    },
+    {
+      "ID Place": "16000US4164900",
+      Place: "Salem, OR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.76492542649183,
+      "Slug Place": "salem-or"
+    },
+    {
+      "ID Place": "16000US5168000",
+      Place: "Roanoke, VA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.628871458027763,
+      "Slug Place": "roanoke-va"
+    },
+    {
+      "ID Place": "16000US0666000",
+      Place: "San Diego, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.8760006450201,
+      "Slug Place": "san-diego-ca"
+    },
+    {
+      "ID Place": "16000US0600562",
+      Place: "Alameda, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 30.215307402760352,
+      "Slug Place": "alameda-ca"
+    },
+    {
+      "ID Place": "16000US4459000",
+      Place: "Providence, RI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 21.84087205850775,
+      "Slug Place": "providence-ri"
+    },
+    {
+      "ID Place": "16000US4202000",
+      Place: "Allentown, PA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.677479818526486,
+      "Slug Place": "allentown-pa"
+    },
+    {
+      "ID Place": "16000US5335415",
+      Place: "Kent, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.710184618358735,
+      "Slug Place": "kent-wa"
+    },
+    {
+      "ID Place": "16000US1703012",
+      Place: "Aurora, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.697071678784223,
+      "Slug Place": "aurora-il"
+    },
+    {
+      "ID Place": "16000US2622000",
+      Place: "Detroit, MI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.970168368957175,
+      "Slug Place": "detroit-mi"
+    },
+    {
+      "ID Place": "16000US0816000",
+      Place: "Colorado Springs, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.73911862721632,
+      "Slug Place": "colorado-springs-co"
+    },
+    {
+      "ID Place": "16000US0653000",
+      Place: "Oakland, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 28.727845728240933,
+      "Slug Place": "oakland-ca"
+    },
+    {
+      "ID Place": "16000US4224000",
+      Place: "Erie, PA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 17.416484807789157,
+      "Slug Place": "erie-pa"
+    },
+    {
+      "ID Place": "16000US0618100",
+      Place: "Davis, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 20.49283235249736,
+      "Slug Place": "davis-ca"
+    },
+    {
+      "ID Place": "16000US1706613",
+      Place: "Bloomington, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.824719268238269,
+      "Slug Place": "bloomington-il"
+    },
+    {
+      "ID Place": "16000US4865000",
+      Place: "San Antonio, TX",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 22.388774107831217,
+      "Slug Place": "san-antonio-tx"
+    },
+    {
+      "ID Place": "16000US2634000",
+      Place: "Grand Rapids, MI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 19.357967113794118,
+      "Slug Place": "grand-rapids-mi"
+    },
+    {
+      "ID Place": "16000US4260000",
+      Place: "Philadelphia, PA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 31.871311644865433,
+      "Slug Place": "philadelphia-pa"
+    },
+    {
+      "ID Place": "16000US1712385",
+      Place: "Champaign, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 15.838,
+      "Slug Place": "champaign-il"
+    },
+    {
+      "ID Place": "16000US0667000",
+      Place: "San Francisco, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 29.51657702646794,
+      "Slug Place": "san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US7206593",
+      Place: "Bayamón, PR",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 33.825444381213806,
+      "Slug Place": "bayamón-pr"
+    },
+    {
+      "ID Place": "16000US0820000",
+      Place: "Denver, CO",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.398863438057656,
+      "Slug Place": "denver-co"
+    },
+    {
+      "ID Place": "16000US4261000",
+      Place: "Pittsburgh, PA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 23.140730273801477,
+      "Slug Place": "pittsburgh-pa"
+    },
+    {
+      "ID Place": "16000US2646000",
+      Place: "Lansing, MI",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.006902502157033,
+      "Slug Place": "lansing-mi"
+    },
+    {
+      "ID Place": "16000US5367000",
+      Place: "Spokane, WA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 18.652044223973025,
+      "Slug Place": "spokane-wa"
+    },
+    {
+      "ID Place": "16000US1714000",
+      Place: "Chicago, IL",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 33.42466980771436,
+      "Slug Place": "chicago-il"
+    },
+    {
+      "ID Place": "16000US0630000",
+      Place: "Glendale, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 26.010046971464032,
+      "Slug Place": "glendale-ca"
+    },
+    {
+      "ID Place": "16000US4263624",
+      Place: "Reading, PA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 24.053241326918208,
+      "Slug Place": "reading-pa"
+    },
+    {
+      "ID Place": "16000US0653322",
+      Place: "Oceanside, CA",
+      "ID Year": 2014,
+      Year: "2014",
+      "Average Commute Time": 25.666918632211445,
+      "Slug Place": "oceanside-ca"
+    },
+    {
+      "ID Place": "16000US1271000",
+      Place: "Tampa, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.036019536019538,
+      "Slug Place": "tampa-fl"
+    },
+    {
+      "ID Place": "16000US4263624",
+      Place: "Reading, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.19313671821541,
+      "Slug Place": "reading-pa"
+    },
+    {
+      "ID Place": "16000US4269000",
+      Place: "Scranton, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.069882046227704,
+      "Slug Place": "scranton-pa"
+    },
+    {
+      "ID Place": "16000US4260000",
+      Place: "Philadelphia, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.086691642393582,
+      "Slug Place": "philadelphia-pa"
+    },
+    {
+      "ID Place": "16000US4224000",
+      Place: "Erie, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 15.383196863909443,
+      "Slug Place": "erie-pa"
+    },
+    {
+      "ID Place": "16000US4459000",
+      Place: "Providence, RI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.8605379795201,
+      "Slug Place": "providence-ri"
+    },
+    {
+      "ID Place": "16000US4202000",
+      Place: "Allentown, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.389680105170903,
+      "Slug Place": "allentown-pa"
+    },
+    {
+      "ID Place": "16000US4164900",
+      Place: "Salem, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.60714494191816,
+      "Slug Place": "salem-or"
+    },
+    {
+      "ID Place": "16000US4159000",
+      Place: "Portland, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.523242230124396,
+      "Slug Place": "portland-or"
+    },
+    {
+      "ID Place": "16000US4134100",
+      Place: "Hillsboro, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.368012645495043,
+      "Slug Place": "hillsboro-or"
+    },
+    {
+      "ID Place": "16000US4513330",
+      Place: "Charleston, SC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.479293855823887,
+      "Slug Place": "charleston-sc"
+    },
+    {
+      "ID Place": "16000US4131250",
+      Place: "Gresham, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.091513451750284,
+      "Slug Place": "gresham-or"
+    },
+    {
+      "ID Place": "16000US4123850",
+      Place: "Eugene, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.56088744170645,
+      "Slug Place": "eugene-or"
+    },
+    {
+      "ID Place": "16000US4105350",
+      Place: "Beaverton, OR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.37529632960026,
+      "Slug Place": "beaverton-or"
+    },
+    {
+      "ID Place": "16000US4075000",
+      Place: "Tulsa, OK",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.259125980678206,
+      "Slug Place": "tulsa-ok"
+    },
+    {
+      "ID Place": "16000US4516000",
+      Place: "Columbia, SC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 15.073274016272542,
+      "Slug Place": "columbia-sc"
+    },
+    {
+      "ID Place": "16000US4055000",
+      Place: "Oklahoma City, OK",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.062771566748292,
+      "Slug Place": "oklahoma-city-ok"
+    },
+    {
+      "ID Place": "16000US3977000",
+      Place: "Toledo, OH",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.24500411347894,
+      "Slug Place": "toledo-oh"
+    },
+    {
+      "ID Place": "16000US3918000",
+      Place: "Columbus, OH",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.591333036463343,
+      "Slug Place": "columbus-oh"
+    },
+    {
+      "ID Place": "16000US3916000",
+      Place: "Cleveland, OH",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.134646244613947,
+      "Slug Place": "cleveland-oh"
+    },
+    {
+      "ID Place": "16000US4550875",
+      Place: "North Charleston, SC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.850647072581275,
+      "Slug Place": "north-charleston-sc"
+    },
+    {
+      "ID Place": "16000US3915000",
+      Place: "Cincinnati, OH",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.351350351735004,
+      "Slug Place": "cincinnati-oh"
+    },
+    {
+      "ID Place": "16000US4659020",
+      Place: "Sioux Falls, SD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.47457402666196,
+      "Slug Place": "sioux-falls-sd"
+    },
+    {
+      "ID Place": "16000US3901000",
+      Place: "Akron, OH",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.9343809601816,
+      "Slug Place": "akron-oh"
+    },
+    {
+      "ID Place": "16000US3825700",
+      Place: "Fargo, ND",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 14.801623366448338,
+      "Slug Place": "fargo-nd"
+    },
+    {
+      "ID Place": "16000US3775000",
+      Place: "Winston-Salem, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.13872460033964,
+      "Slug Place": "winston-salem-nc"
+    },
+    {
+      "ID Place": "16000US3774440",
+      Place: "Wilmington, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.970201608617085,
+      "Slug Place": "wilmington-nc"
+    },
+    {
+      "ID Place": "16000US4714000",
+      Place: "Chattanooga, TN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.636976678842373,
+      "Slug Place": "chattanooga-tn"
+    },
+    {
+      "ID Place": "16000US3755000",
+      Place: "Raleigh, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.61755631667904,
+      "Slug Place": "raleigh-nc"
+    },
+    {
+      "ID Place": "16000US3728000",
+      Place: "Greensboro, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.53455949380664,
+      "Slug Place": "greensboro-nc"
+    },
+    {
+      "ID Place": "16000US3722920",
+      Place: "Fayetteville, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.751593406593408,
+      "Slug Place": "fayetteville-nc"
+    },
+    {
+      "ID Place": "16000US3719000",
+      Place: "Durham, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.50862588973338,
+      "Slug Place": "durham-nc"
+    },
+    {
+      "ID Place": "16000US4715160",
+      Place: "Clarksville, TN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.68215904142947,
+      "Slug Place": "clarksville-tn"
+    },
+    {
+      "ID Place": "16000US3712000",
+      Place: "Charlotte, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.70315644637943,
+      "Slug Place": "charlotte-nc"
+    },
+    {
+      "ID Place": "16000US3710740",
+      Place: "Cary, NC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.248569354024884,
+      "Slug Place": "cary-nc"
+    },
+    {
+      "ID Place": "16000US3684000",
+      Place: "Yonkers, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.658192952129163,
+      "Slug Place": "yonkers-ny"
+    },
+    {
+      "ID Place": "16000US4740000",
+      Place: "Knoxville, TN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.499025519913786,
+      "Slug Place": "knoxville-tn"
+    },
+    {
+      "ID Place": "16000US3673000",
+      Place: "Syracuse, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.106785297949667,
+      "Slug Place": "syracuse-ny"
+    },
+    {
+      "ID Place": "16000US3663000",
+      Place: "Rochester, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.25697161703687,
+      "Slug Place": "rochester-ny"
+    },
+    {
+      "ID Place": "16000US3651000",
+      Place: "New York, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 38.046458703665834,
+      "Slug Place": "new-york-ny"
+    },
+    {
+      "ID Place": "16000US4748000",
+      Place: "Memphis, TN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.440285690724014,
+      "Slug Place": "memphis-tn"
+    },
+    {
+      "ID Place": "16000US3650617",
+      Place: "New Rochelle, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.443716412334396,
+      "Slug Place": "new-rochelle-ny"
+    },
+    {
+      "ID Place": "16000US3649121",
+      Place: "Mount Vernon, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.294870579311652,
+      "Slug Place": "mount-vernon-ny"
+    },
+    {
+      "ID Place": "16000US3611000",
+      Place: "Buffalo, NY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.356776754402865,
+      "Slug Place": "buffalo-ny"
+    },
+    {
+      "ID Place": "16000US3502000",
+      Place: "Albuquerque, NM",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.85579875932807,
+      "Slug Place": "albuquerque-nm"
+    },
+    {
+      "ID Place": "16000US4752006",
+      Place: "Nashville-Davidson metropolitan government (balance), TN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.20527351703543,
+      "Slug Place": "nashville-davidson-metropolitan-government-(balance)-tn"
+    },
+    {
+      "ID Place": "16000US3474630",
+      Place: "Union City, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.46347793845013,
+      "Slug Place": "union-city-nj"
+    },
+    {
+      "ID Place": "16000US3474000",
+      Place: "Trenton, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.70851110987976,
+      "Slug Place": "trenton-nj"
+    },
+    {
+      "ID Place": "16000US3457000",
+      Place: "Paterson, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.62240568943968,
+      "Slug Place": "paterson-nj"
+    },
+    {
+      "ID Place": "16000US3456550",
+      Place: "Passaic, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.273213211087118,
+      "Slug Place": "passaic-nj"
+    },
+    {
+      "ID Place": "16000US3451000",
+      Place: "Newark, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 35.167526855628246,
+      "Slug Place": "newark-nj"
+    },
+    {
+      "ID Place": "16000US4803000",
+      Place: "Amarillo, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.369038352863402,
+      "Slug Place": "amarillo-tx"
+    },
+    {
+      "ID Place": "16000US3436000",
+      Place: "Jersey City, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 34.869823320446365,
+      "Slug Place": "jersey-city-nj"
+    },
+    {
+      "ID Place": "16000US3421000",
+      Place: "Elizabeth, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.0193296875846,
+      "Slug Place": "elizabeth-nj"
+    },
+    {
+      "ID Place": "16000US4804000",
+      Place: "Arlington, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.60771609087243,
+      "Slug Place": "arlington-tx"
+    },
+    {
+      "ID Place": "16000US3413690",
+      Place: "Clifton, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.085271317829456,
+      "Slug Place": "clifton-nj"
+    },
+    {
+      "ID Place": "16000US3403580",
+      Place: "Bayonne, NJ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 35.61393031430229,
+      "Slug Place": "bayonne-nj"
+    },
+    {
+      "ID Place": "16000US3271400",
+      Place: "Sunrise Manor, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.38947153364206,
+      "Slug Place": "sunrise-manor-nv"
+    },
+    {
+      "ID Place": "16000US3268585",
+      Place: "Spring Valley, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.845206805920597,
+      "Slug Place": "spring-valley-nv"
+    },
+    {
+      "ID Place": "16000US4805000",
+      Place: "Austin, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.86786369528574,
+      "Slug Place": "austin-tx"
+    },
+    {
+      "ID Place": "16000US3260600",
+      Place: "Reno, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.30275106599347,
+      "Slug Place": "reno-nv"
+    },
+    {
+      "ID Place": "16000US3254600",
+      Place: "Paradise, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.751380223528884,
+      "Slug Place": "paradise-nv"
+    },
+    {
+      "ID Place": "16000US3251800",
+      Place: "North Las Vegas, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.28618255168936,
+      "Slug Place": "north-las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US3240000",
+      Place: "Las Vegas, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.147632515351567,
+      "Slug Place": "las-vegas-nv"
+    },
+    {
+      "ID Place": "16000US3231900",
+      Place: "Henderson, NV",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.957001423579655,
+      "Slug Place": "henderson-nv"
+    },
+    {
+      "ID Place": "16000US3137000",
+      Place: "Omaha, NE",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.8781250425446,
+      "Slug Place": "omaha-ne"
+    },
+    {
+      "ID Place": "16000US3128000",
+      Place: "Lincoln, NE",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.227743444128947,
+      "Slug Place": "lincoln-ne"
+    },
+    {
+      "ID Place": "16000US3006550",
+      Place: "Billings, MT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 15.741805203343665,
+      "Slug Place": "billings-mt"
+    },
+    {
+      "ID Place": "16000US2970000",
+      Place: "Springfield, MO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.383273780269118,
+      "Slug Place": "springfield-mo"
+    },
+    {
+      "ID Place": "16000US2965000",
+      Place: "St. Louis, MO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.4205853178044,
+      "Slug Place": "st.-louis-mo"
+    },
+    {
+      "ID Place": "16000US2938000",
+      Place: "Kansas City, MO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.341778672172726,
+      "Slug Place": "kansas-city-mo"
+    },
+    {
+      "ID Place": "16000US2915670",
+      Place: "Columbia, MO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 14.849127503789957,
+      "Slug Place": "columbia-mo"
+    },
+    {
+      "ID Place": "16000US2836000",
+      Place: "Jackson, MS",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.089583071619,
+      "Slug Place": "jackson-ms"
+    },
+    {
+      "ID Place": "16000US4817000",
+      Place: "Corpus Christi, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.64843523274099,
+      "Slug Place": "corpus-christi-tx"
+    },
+    {
+      "ID Place": "16000US2758000",
+      Place: "St. Paul, MN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.752823736658492,
+      "Slug Place": "st.-paul-mn"
+    },
+    {
+      "ID Place": "16000US2754880",
+      Place: "Rochester, MN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 15.711993302169818,
+      "Slug Place": "rochester-mn"
+    },
+    {
+      "ID Place": "16000US2743000",
+      Place: "Minneapolis, MN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.062439418042178,
+      "Slug Place": "minneapolis-mn"
+    },
+    {
+      "ID Place": "16000US2717000",
+      Place: "Duluth, MN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.022202965079515,
+      "Slug Place": "duluth-mn"
+    },
+    {
+      "ID Place": "16000US4819000",
+      Place: "Dallas, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.70578336609138,
+      "Slug Place": "dallas-tx"
+    },
+    {
+      "ID Place": "16000US2706616",
+      Place: "Bloomington, MN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.784435609638237,
+      "Slug Place": "bloomington-mn"
+    },
+    {
+      "ID Place": "16000US2646000",
+      Place: "Lansing, MI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.026885043263288,
+      "Slug Place": "lansing-mi"
+    },
+    {
+      "ID Place": "16000US2634000",
+      Place: "Grand Rapids, MI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.475744338429706,
+      "Slug Place": "grand-rapids-mi"
+    },
+    {
+      "ID Place": "16000US2622000",
+      Place: "Detroit, MI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.802428116875557,
+      "Slug Place": "detroit-mi"
+    },
+    {
+      "ID Place": "16000US4819972",
+      Place: "Denton, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.339768656961652,
+      "Slug Place": "denton-tx"
+    },
+    {
+      "ID Place": "16000US2603000",
+      Place: "Ann Arbor, MI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.986887896790524,
+      "Slug Place": "ann-arbor-mi"
+    },
+    {
+      "ID Place": "16000US2582000",
+      Place: "Worcester, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.412420568855957,
+      "Slug Place": "worcester-ma"
+    },
+    {
+      "ID Place": "16000US2567000",
+      Place: "Springfield, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.0498926855858,
+      "Slug Place": "springfield-ma"
+    },
+    {
+      "ID Place": "16000US2562535",
+      Place: "Somerville, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.806766901212654,
+      "Slug Place": "somerville-ma"
+    },
+    {
+      "ID Place": "16000US4824000",
+      Place: "El Paso, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.468176354700823,
+      "Slug Place": "el-paso-tx"
+    },
+    {
+      "ID Place": "16000US2555745",
+      Place: "Quincy, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.473158501324384,
+      "Slug Place": "quincy-ma"
+    },
+    {
+      "ID Place": "16000US2545560",
+      Place: "Newton, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.014100839556566,
+      "Slug Place": "newton-ma"
+    },
+    {
+      "ID Place": "16000US2537490",
+      Place: "Lynn, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.213422259274697,
+      "Slug Place": "lynn-ma"
+    },
+    {
+      "ID Place": "16000US2537000",
+      Place: "Lowell, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.224049538591448,
+      "Slug Place": "lowell-ma"
+    },
+    {
+      "ID Place": "16000US4827000",
+      Place: "Fort Worth, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.47904026017843,
+      "Slug Place": "fort-worth-tx"
+    },
+    {
+      "ID Place": "16000US2534550",
+      Place: "Lawrence, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.57679663256214,
+      "Slug Place": "lawrence-ma"
+    },
+    {
+      "ID Place": "16000US2524960",
+      Place: "Framingham, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.840837948470984,
+      "Slug Place": "framingham-ma"
+    },
+    {
+      "ID Place": "16000US2511000",
+      Place: "Cambridge, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.21671124352507,
+      "Slug Place": "cambridge-ma"
+    },
+    {
+      "ID Place": "16000US2509000",
+      Place: "Brockton, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.274725536424473,
+      "Slug Place": "brockton-ma"
+    },
+    {
+      "ID Place": "16000US4829000",
+      Place: "Garland, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.802287312818827,
+      "Slug Place": "garland-tx"
+    },
+    {
+      "ID Place": "16000US2507000",
+      Place: "Boston, MA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.53076713763653,
+      "Slug Place": "boston-ma"
+    },
+    {
+      "ID Place": "16000US2472450",
+      Place: "Silver Spring, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.06863935727965,
+      "Slug Place": "silver-spring-md"
+    },
+    {
+      "ID Place": "16000US2432025",
+      Place: "Germantown, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 36.22917448961442,
+      "Slug Place": "germantown-md"
+    },
+    {
+      "ID Place": "16000US2430325",
+      Place: "Frederick, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.119365277620076,
+      "Slug Place": "frederick-md"
+    },
+    {
+      "ID Place": "16000US2419125",
+      Place: "Columbia, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.34302265969445,
+      "Slug Place": "columbia-md"
+    },
+    {
+      "ID Place": "16000US2407125",
+      Place: "Bethesda, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.884253028263796,
+      "Slug Place": "bethesda-md"
+    },
+    {
+      "ID Place": "16000US4835000",
+      Place: "Houston, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.362298139222652,
+      "Slug Place": "houston-tx"
+    },
+    {
+      "ID Place": "16000US2404000",
+      Place: "Baltimore, MD",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.71363349541591,
+      "Slug Place": "baltimore-md"
+    },
+    {
+      "ID Place": "16000US2360545",
+      Place: "Portland, ME",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.67241176123976,
+      "Slug Place": "portland-me"
+    },
+    {
+      "ID Place": "16000US2270000",
+      Place: "Shreveport, LA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.275553006130572,
+      "Slug Place": "shreveport-la"
+    },
+    {
+      "ID Place": "16000US2255000",
+      Place: "New Orleans, LA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.025023006629425,
+      "Slug Place": "new-orleans-la"
+    },
+    {
+      "ID Place": "16000US4837000",
+      Place: "Irving, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.010786612662546,
+      "Slug Place": "irving-tx"
+    },
+    {
+      "ID Place": "16000US2250115",
+      Place: "Metairie, LA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.348770553627997,
+      "Slug Place": "metairie-la"
+    },
+    {
+      "ID Place": "16000US2205000",
+      Place: "Baton Rouge, LA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.665286794624556,
+      "Slug Place": "baton-rouge-la"
+    },
+    {
+      "ID Place": "16000US2148006",
+      Place: "Louisville/Jefferson County metro government (balance), KY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.110615205871518,
+      "Slug Place": "louisville-jefferson-county-metro-government-(balance)-ky"
+    },
+    {
+      "ID Place": "16000US2146027",
+      Place: "Lexington-Fayette, KY",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.127602894529442,
+      "Slug Place": "lexington-fayette-ky"
+    },
+    {
+      "ID Place": "16000US4841464",
+      Place: "Laredo, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.19031458920148,
+      "Slug Place": "laredo-tx"
+    },
+    {
+      "ID Place": "16000US2079000",
+      Place: "Wichita, KS",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.071448454516016,
+      "Slug Place": "wichita-ks"
+    },
+    {
+      "ID Place": "16000US2036000",
+      Place: "Kansas City, KS",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.763129857107046,
+      "Slug Place": "kansas-city-ks"
+    },
+    {
+      "ID Place": "16000US1938595",
+      Place: "Iowa City, IA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.756661815627037,
+      "Slug Place": "iowa-city-ia"
+    },
+    {
+      "ID Place": "16000US1921000",
+      Place: "Des Moines, IA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.530572923553525,
+      "Slug Place": "des-moines-ia"
+    },
+    {
+      "ID Place": "16000US4845000",
+      Place: "Lubbock, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 14.941444458151954,
+      "Slug Place": "lubbock-tx"
+    },
+    {
+      "ID Place": "16000US1871000",
+      Place: "South Bend, IN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.45542439572794,
+      "Slug Place": "south-bend-in"
+    },
+    {
+      "ID Place": "16000US1836003",
+      Place: "Indianapolis city (balance), IN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.919558921980286,
+      "Slug Place": "indianapolis-city-(balance)-in"
+    },
+    {
+      "ID Place": "16000US1825000",
+      Place: "Fort Wayne, IN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.734216464985696,
+      "Slug Place": "fort-wayne-in"
+    },
+    {
+      "ID Place": "16000US1822000",
+      Place: "Evansville, IN",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.202270319963226,
+      "Slug Place": "evansville-in"
+    },
+    {
+      "ID Place": "16000US1770122",
+      Place: "Skokie, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.83732382407879,
+      "Slug Place": "skokie-il"
+    },
+    {
+      "ID Place": "16000US4847892",
+      Place: "Mesquite, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.228711228110335,
+      "Slug Place": "mesquite-tx"
+    },
+    {
+      "ID Place": "16000US1765000",
+      Place: "Rockford, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.775020322287574,
+      "Slug Place": "rockford-il"
+    },
+    {
+      "ID Place": "16000US4858016",
+      Place: "Plano, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.364494773519162,
+      "Slug Place": "plano-tx"
+    },
+    {
+      "ID Place": "16000US1759000",
+      Place: "Peoria, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.63200673743586,
+      "Slug Place": "peoria-il"
+    },
+    {
+      "ID Place": "16000US1751622",
+      Place: "Naperville, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.370576698973935,
+      "Slug Place": "naperville-il"
+    },
+    {
+      "ID Place": "16000US1738570",
+      Place: "Joliet, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.374788282251057,
+      "Slug Place": "joliet-il"
+    },
+    {
+      "ID Place": "16000US1724582",
+      Place: "Evanston, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.50286640801436,
+      "Slug Place": "evanston-il"
+    },
+    {
+      "ID Place": "16000US1723074",
+      Place: "Elgin, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.430697854243185,
+      "Slug Place": "elgin-il"
+    },
+    {
+      "ID Place": "16000US1714351",
+      Place: "Cicero, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.990726574452804,
+      "Slug Place": "cicero-il"
+    },
+    {
+      "ID Place": "16000US1714000",
+      Place: "Chicago, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.20251593632374,
+      "Slug Place": "chicago-il"
+    },
+    {
+      "ID Place": "16000US4865000",
+      Place: "San Antonio, TX",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.622308629795135,
+      "Slug Place": "san-antonio-tx"
+    },
+    {
+      "ID Place": "16000US1712385",
+      Place: "Champaign, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 14.497706537627904,
+      "Slug Place": "champaign-il"
+    },
+    {
+      "ID Place": "16000US1703012",
+      Place: "Aurora, IL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.154465498286232,
+      "Slug Place": "aurora-il"
+    },
+    {
+      "ID Place": "16000US1608830",
+      Place: "Boise City, ID",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.55795363709033,
+      "Slug Place": "boise-city-id"
+    },
+    {
+      "ID Place": "16000US1571550",
+      Place: "Urban Honolulu, HI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.377542659684373,
+      "Slug Place": "urban-honolulu-hi"
+    },
+    {
+      "ID Place": "16000US1369000",
+      Place: "Savannah, GA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.898732881968723,
+      "Slug Place": "savannah-ga"
+    },
+    {
+      "ID Place": "16000US4955980",
+      Place: "Ogden, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.39228823218704,
+      "Slug Place": "ogden-ut"
+    },
+    {
+      "ID Place": "16000US1368516",
+      Place: "Sandy Springs, GA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.52320667419578,
+      "Slug Place": "sandy-springs-ga"
+    },
+    {
+      "ID Place": "16000US1319000",
+      Place: "Columbus, GA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.720896267176222,
+      "Slug Place": "columbus-ga"
+    },
+    {
+      "ID Place": "16000US1304204",
+      Place: "Augusta-Richmond County consolidated government (balance), GA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.727411779038132,
+      "Slug Place":
+        "augusta-richmond-county-consolidated-government-(balance)-ga"
+    },
+    {
+      "ID Place": "16000US4957300",
+      Place: "Orem, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.61007536691789,
+      "Slug Place": "orem-ut"
+    },
+    {
+      "ID Place": "16000US1304000",
+      Place: "Atlanta, GA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.684813406630663,
+      "Slug Place": "atlanta-ga"
+    },
+    {
+      "ID Place": "16000US4261000",
+      Place: "Pittsburgh, PA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.65489103059203,
+      "Slug Place": "pittsburgh-pa"
+    },
+    {
+      "ID Place": "16000US1270600",
+      Place: "Tallahassee, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.205565640962035,
+      "Slug Place": "tallahassee-fl"
+    },
+    {
+      "ID Place": "16000US1263000",
+      Place: "St. Petersburg, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.500205879930824,
+      "Slug Place": "st.-petersburg-fl"
+    },
+    {
+      "ID Place": "16000US4962470",
+      Place: "Provo, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.1775735983499,
+      "Slug Place": "provo-ut"
+    },
+    {
+      "ID Place": "16000US1253000",
+      Place: "Orlando, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.432958662043394,
+      "Slug Place": "orlando-fl"
+    },
+    {
+      "ID Place": "16000US1245025",
+      Place: "Miami Beach, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.122207103275553,
+      "Slug Place": "miami-beach-fl"
+    },
+    {
+      "ID Place": "16000US1245000",
+      Place: "Miami, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.49773637924754,
+      "Slug Place": "miami-fl"
+    },
+    {
+      "ID Place": "16000US1235000",
+      Place: "Jacksonville, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.21956037631663,
+      "Slug Place": "jacksonville-fl"
+    },
+    {
+      "ID Place": "16000US4967000",
+      Place: "Salt Lake City, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.80663728286233,
+      "Slug Place": "salt-lake-city-ut"
+    },
+    {
+      "ID Place": "16000US1232000",
+      Place: "Hollywood, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.940989593384895,
+      "Slug Place": "hollywood-fl"
+    },
+    {
+      "ID Place": "16000US1230000",
+      Place: "Hialeah, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.719464607896615,
+      "Slug Place": "hialeah-fl"
+    },
+    {
+      "ID Place": "16000US1225175",
+      Place: "Gainesville, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 15.05820519503084,
+      "Slug Place": "gainesville-fl"
+    },
+    {
+      "ID Place": "16000US1224000",
+      Place: "Fort Lauderdale, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.31449157215815,
+      "Slug Place": "fort-lauderdale-fl"
+    },
+    {
+      "ID Place": "16000US4967440",
+      Place: "Sandy, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.732564740818376,
+      "Slug Place": "sandy-ut"
+    },
+    {
+      "ID Place": "16000US1212875",
+      Place: "Clearwater, FL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.22915298752462,
+      "Slug Place": "clearwater-fl"
+    },
+    {
+      "ID Place": "16000US1150000",
+      Place: "Washington, DC",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.632421149575716,
+      "Slug Place": "washington-dc"
+    },
+    {
+      "ID Place": "16000US0973000",
+      Place: "Stamford, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.09850640113798,
+      "Slug Place": "stamford-ct"
+    },
+    {
+      "ID Place": "16000US4982950",
+      Place: "West Jordan, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.696783533473152,
+      "Slug Place": "west-jordan-ut"
+    },
+    {
+      "ID Place": "16000US0955990",
+      Place: "Norwalk, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.903526681137308,
+      "Slug Place": "norwalk-ct"
+    },
+    {
+      "ID Place": "16000US0952000",
+      Place: "New Haven, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.65796483750666,
+      "Slug Place": "new-haven-ct"
+    },
+    {
+      "ID Place": "16000US4983470",
+      Place: "West Valley City, UT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.31919795221843,
+      "Slug Place": "west-valley-city-ut"
+    },
+    {
+      "ID Place": "16000US0950370",
+      Place: "New Britain, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.739276292219003,
+      "Slug Place": "new-britain-ct"
+    },
+    {
+      "ID Place": "16000US0937000",
+      Place: "Hartford, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.626021692167214,
+      "Slug Place": "hartford-ct"
+    },
+    {
+      "ID Place": "16000US0918430",
+      Place: "Danbury, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.743761232057143,
+      "Slug Place": "danbury-ct"
+    },
+    {
+      "ID Place": "16000US5101000",
+      Place: "Alexandria, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.3914468347448,
+      "Slug Place": "alexandria-va"
+    },
+    {
+      "ID Place": "16000US0908000",
+      Place: "Bridgeport, CT",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.754026554729204,
+      "Slug Place": "bridgeport-ct"
+    },
+    {
+      "ID Place": "16000US0877290",
+      Place: "Thornton, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.45188758660882,
+      "Slug Place": "thornton-co"
+    },
+    {
+      "ID Place": "16000US0862000",
+      Place: "Pueblo, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.072638313887843,
+      "Slug Place": "pueblo-co"
+    },
+    {
+      "ID Place": "16000US0845970",
+      Place: "Longmont, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.272119446138557,
+      "Slug Place": "longmont-co"
+    },
+    {
+      "ID Place": "16000US5103000",
+      Place: "Arlington, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.82653602631672,
+      "Slug Place": "arlington-va"
+    },
+    {
+      "ID Place": "16000US0843000",
+      Place: "Lakewood, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.992628257439748,
+      "Slug Place": "lakewood-co"
+    },
+    {
+      "ID Place": "16000US0836410",
+      Place: "Highlands Ranch, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.38045990293506,
+      "Slug Place": "highlands-ranch-co"
+    },
+    {
+      "ID Place": "16000US0832155",
+      Place: "Greeley, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.91820493501601,
+      "Slug Place": "greeley-co"
+    },
+    {
+      "ID Place": "16000US0827425",
+      Place: "Fort Collins, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.094154401026124,
+      "Slug Place": "fort-collins-co"
+    },
+    {
+      "ID Place": "16000US0820000",
+      Place: "Denver, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.106186400366532,
+      "Slug Place": "denver-co"
+    },
+    {
+      "ID Place": "16000US0816000",
+      Place: "Colorado Springs, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.98825002038262,
+      "Slug Place": "colorado-springs-co"
+    },
+    {
+      "ID Place": "16000US5116000",
+      Place: "Chesapeake, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.112809167654028,
+      "Slug Place": "chesapeake-va"
+    },
+    {
+      "ID Place": "16000US0812815",
+      Place: "Centennial, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.673188486124968,
+      "Slug Place": "centennial-co"
+    },
+    {
+      "ID Place": "16000US0807850",
+      Place: "Boulder, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.67084341513999,
+      "Slug Place": "boulder-co"
+    },
+    {
+      "ID Place": "16000US0804000",
+      Place: "Aurora, CO",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.62058864640498,
+      "Slug Place": "aurora-co"
+    },
+    {
+      "ID Place": "16000US0684200",
+      Place: "West Covina, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.754942873349,
+      "Slug Place": "west-covina-ca"
+    },
+    {
+      "ID Place": "16000US0682954",
+      Place: "Visalia, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.767709037291883,
+      "Slug Place": "visalia-ca"
+    },
+    {
+      "ID Place": "16000US0681666",
+      Place: "Vallejo, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.97377404715049,
+      "Slug Place": "vallejo-ca"
+    },
+    {
+      "ID Place": "16000US0681344",
+      Place: "Upland, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.382829697818693,
+      "Slug Place": "upland-ca"
+    },
+    {
+      "ID Place": "16000US0681204",
+      Place: "Union City, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.88380493678507,
+      "Slug Place": "union-city-ca"
+    },
+    {
+      "ID Place": "16000US0680238",
+      Place: "Tracy, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 40.980695082659906,
+      "Slug Place": "tracy-ca"
+    },
+    {
+      "ID Place": "16000US0680000",
+      Place: "Torrance, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.586980103337044,
+      "Slug Place": "torrance-ca"
+    },
+    {
+      "ID Place": "16000US5156000",
+      Place: "Newport News, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.001507099230587,
+      "Slug Place": "newport-news-va"
+    },
+    {
+      "ID Place": "16000US0677000",
+      Place: "Sunnyvale, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.55608952354799,
+      "Slug Place": "sunnyvale-ca"
+    },
+    {
+      "ID Place": "16000US0675000",
+      Place: "Stockton, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.298016316178,
+      "Slug Place": "stockton-ca"
+    },
+    {
+      "ID Place": "16000US0673262",
+      Place: "South San Francisco, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.16639790671494,
+      "Slug Place": "south-san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US0672016",
+      Place: "Simi Valley, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.814247272844458,
+      "Slug Place": "simi-valley-ca"
+    },
+    {
+      "ID Place": "16000US5157000",
+      Place: "Norfolk, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.282069078141586,
+      "Slug Place": "norfolk-va"
+    },
+    {
+      "ID Place": "16000US0670098",
+      Place: "Santa Rosa, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.374670831036806,
+      "Slug Place": "santa-rosa-ca"
+    },
+    {
+      "ID Place": "16000US0669196",
+      Place: "Santa Maria, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.426879647480032,
+      "Slug Place": "santa-maria-ca"
+    },
+    {
+      "ID Place": "16000US0669088",
+      Place: "Santa Clarita, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.82363304981774,
+      "Slug Place": "santa-clarita-ca"
+    },
+    {
+      "ID Place": "16000US0669084",
+      Place: "Santa Clara, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.04932793105666,
+      "Slug Place": "santa-clara-ca"
+    },
+    {
+      "ID Place": "16000US0669000",
+      Place: "Santa Ana, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.679828709191895,
+      "Slug Place": "santa-ana-ca"
+    },
+    {
+      "ID Place": "16000US5167000",
+      Place: "Richmond, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.836040820049252,
+      "Slug Place": "richmond-va"
+    },
+    {
+      "ID Place": "16000US0668252",
+      Place: "San Mateo, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.280891392467694,
+      "Slug Place": "san-mateo-ca"
+    },
+    {
+      "ID Place": "16000US0668084",
+      Place: "San Leandro, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.273048797973523,
+      "Slug Place": "san-leandro-ca"
+    },
+    {
+      "ID Place": "16000US0668000",
+      Place: "San Jose, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.201656053115805,
+      "Slug Place": "san-jose-ca"
+    },
+    {
+      "ID Place": "16000US0667000",
+      Place: "San Francisco, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.36707454137907,
+      "Slug Place": "san-francisco-ca"
+    },
+    {
+      "ID Place": "16000US0666000",
+      Place: "San Diego, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.8462774496418,
+      "Slug Place": "san-diego-ca"
+    },
+    {
+      "ID Place": "16000US5182000",
+      Place: "Virginia Beach, VA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.45267994396113,
+      "Slug Place": "virginia-beach-va"
+    },
+    {
+      "ID Place": "16000US0665042",
+      Place: "San Buenaventura (Ventura), CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.102360184710108,
+      "Slug Place": "san-buenaventura-(ventura)-ca"
+    },
+    {
+      "ID Place": "16000US0665000",
+      Place: "San Bernardino, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.455374059826607,
+      "Slug Place": "san-bernardino-ca"
+    },
+    {
+      "ID Place": "16000US0664224",
+      Place: "Salinas, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.72587245835079,
+      "Slug Place": "salinas-ca"
+    },
+    {
+      "ID Place": "16000US0664000",
+      Place: "Sacramento, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.609125907162817,
+      "Slug Place": "sacramento-ca"
+    },
+    {
+      "ID Place": "16000US5303180",
+      Place: "Auburn, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.62589056079463,
+      "Slug Place": "auburn-wa"
+    },
+    {
+      "ID Place": "16000US0662938",
+      Place: "Roseville, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.800272127127045,
+      "Slug Place": "roseville-ca"
+    },
+    {
+      "ID Place": "16000US0662000",
+      Place: "Riverside, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.636253022743272,
+      "Slug Place": "riverside-ca"
+    },
+    {
+      "ID Place": "16000US0660620",
+      Place: "Richmond, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.87506885085375,
+      "Slug Place": "richmond-ca"
+    },
+    {
+      "ID Place": "16000US5305210",
+      Place: "Bellevue, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.037374972564514,
+      "Slug Place": "bellevue-wa"
+    },
+    {
+      "ID Place": "16000US0660102",
+      Place: "Redwood City, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.40996668767444,
+      "Slug Place": "redwood-city-ca"
+    },
+    {
+      "ID Place": "16000US0659451",
+      Place: "Rancho Cucamonga, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.97296598445964,
+      "Slug Place": "rancho-cucamonga-ca"
+    },
+    {
+      "ID Place": "16000US0658072",
+      Place: "Pomona, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.756855430138383,
+      "Slug Place": "pomona-ca"
+    },
+    {
+      "ID Place": "16000US5305280",
+      Place: "Bellingham, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.178834251181833,
+      "Slug Place": "bellingham-wa"
+    },
+    {
+      "ID Place": "16000US0656000",
+      Place: "Pasadena, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.819590798557734,
+      "Slug Place": "pasadena-ca"
+    },
+    {
+      "ID Place": "16000US0655282",
+      Place: "Palo Alto, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.564429024973,
+      "Slug Place": "palo-alto-ca"
+    },
+    {
+      "ID Place": "16000US0655156",
+      Place: "Palmdale, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 40.77731717129314,
+      "Slug Place": "palmdale-ca"
+    },
+    {
+      "ID Place": "16000US5322640",
+      Place: "Everett, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.97974036191975,
+      "Slug Place": "everett-wa"
+    },
+    {
+      "ID Place": "16000US0654652",
+      Place: "Oxnard, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.73522130692731,
+      "Slug Place": "oxnard-ca"
+    },
+    {
+      "ID Place": "16000US0653980",
+      Place: "Orange, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.526230474506338,
+      "Slug Place": "orange-ca"
+    },
+    {
+      "ID Place": "16000US0653322",
+      Place: "Oceanside, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.623047466872364,
+      "Slug Place": "oceanside-ca"
+    },
+    {
+      "ID Place": "16000US5335415",
+      Place: "Kent, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.81201044386423,
+      "Slug Place": "kent-wa"
+    },
+    {
+      "ID Place": "16000US0653000",
+      Place: "Oakland, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.772131543821665,
+      "Slug Place": "oakland-ca"
+    },
+    {
+      "ID Place": "16000US0649670",
+      Place: "Mountain View, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.147644168723254,
+      "Slug Place": "mountain-view-ca"
+    },
+    {
+      "ID Place": "16000US0649270",
+      Place: "Moreno Valley, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.718878832971484,
+      "Slug Place": "moreno-valley-ca"
+    },
+    {
+      "ID Place": "16000US0648354",
+      Place: "Modesto, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.52947986953166,
+      "Slug Place": "modesto-ca"
+    },
+    {
+      "ID Place": "16000US0644000",
+      Place: "Los Angeles, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.281272821480556,
+      "Slug Place": "los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US0643000",
+      Place: "Long Beach, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.368687709616804,
+      "Slug Place": "long-beach-ca"
+    },
+    {
+      "ID Place": "16000US5357745",
+      Place: "Renton, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.94456861868574,
+      "Slug Place": "renton-wa"
+    },
+    {
+      "ID Place": "16000US0640130",
+      Place: "Lancaster, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.59196545964962,
+      "Slug Place": "lancaster-ca"
+    },
+    {
+      "ID Place": "16000US0636770",
+      Place: "Irvine, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.111885695527853,
+      "Slug Place": "irvine-ca"
+    },
+    {
+      "ID Place": "16000US5363000",
+      Place: "Seattle, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.46155778290228,
+      "Slug Place": "seattle-wa"
+    },
+    {
+      "ID Place": "16000US0636546",
+      Place: "Inglewood, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.992733003545943,
+      "Slug Place": "inglewood-ca"
+    },
+    {
+      "ID Place": "16000US0636000",
+      Place: "Huntington Beach, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.30723863855532,
+      "Slug Place": "huntington-beach-ca"
+    },
+    {
+      "ID Place": "16000US0633000",
+      Place: "Hayward, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.62934100344305,
+      "Slug Place": "hayward-ca"
+    },
+    {
+      "ID Place": "16000US0632548",
+      Place: "Hawthorne, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.662092666765563,
+      "Slug Place": "hawthorne-ca"
+    },
+    {
+      "ID Place": "16000US5367000",
+      Place: "Spokane, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.768566896291613,
+      "Slug Place": "spokane-wa"
+    },
+    {
+      "ID Place": "16000US0630000",
+      Place: "Glendale, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.479876231429028,
+      "Slug Place": "glendale-ca"
+    },
+    {
+      "ID Place": "16000US0629000",
+      Place: "Garden Grove, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.408540754057682,
+      "Slug Place": "garden-grove-ca"
+    },
+    {
+      "ID Place": "16000US0628000",
+      Place: "Fullerton, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.61075925676384,
+      "Slug Place": "fullerton-ca"
+    },
+    {
+      "ID Place": "16000US0627000",
+      Place: "Fresno, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.686812897796013,
+      "Slug Place": "fresno-ca"
+    },
+    {
+      "ID Place": "16000US5370000",
+      Place: "Tacoma, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.23600109259765,
+      "Slug Place": "tacoma-wa"
+    },
+    {
+      "ID Place": "16000US0626000",
+      Place: "Fremont, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.13372093023256,
+      "Slug Place": "fremont-ca"
+    },
+    {
+      "ID Place": "16000US0624680",
+      Place: "Fontana, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.93133083120174,
+      "Slug Place": "fontana-ca"
+    },
+    {
+      "ID Place": "16000US0623182",
+      Place: "Fairfield, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.420308649980548,
+      "Slug Place": "fairfield-ca"
+    },
+    {
+      "ID Place": "16000US0622804",
+      Place: "Escondido, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.35814140913177,
+      "Slug Place": "escondido-ca"
+    },
+    {
+      "ID Place": "16000US5374060",
+      Place: "Vancouver, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.156284530386742,
+      "Slug Place": "vancouver-wa"
+    },
+    {
+      "ID Place": "16000US0622230",
+      Place: "El Monte, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 32.38427567901517,
+      "Slug Place": "el-monte-ca"
+    },
+    {
+      "ID Place": "16000US0622020",
+      Place: "Elk Grove, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.383590190193303,
+      "Slug Place": "elk-grove-ca"
+    },
+    {
+      "ID Place": "16000US0620802",
+      Place: "East Los Angeles, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 30.596306885436963,
+      "Slug Place": "east-los-angeles-ca"
+    },
+    {
+      "ID Place": "16000US0617918",
+      Place: "Daly City, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.39478918765318,
+      "Slug Place": "daly-city-ca"
+    },
+    {
+      "ID Place": "16000US5380010",
+      Place: "Yakima, WA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.90468024482904,
+      "Slug Place": "yakima-wa"
+    },
+    {
+      "ID Place": "16000US0616532",
+      Place: "Costa Mesa, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.96467168756925,
+      "Slug Place": "costa-mesa-ca"
+    },
+    {
+      "ID Place": "16000US5531000",
+      Place: "Green Bay, WI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.52426211100417,
+      "Slug Place": "green-bay-wi"
+    },
+    {
+      "ID Place": "16000US0616350",
+      Place: "Corona, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 33.48727133171293,
+      "Slug Place": "corona-ca"
+    },
+    {
+      "ID Place": "16000US0616000",
+      Place: "Concord, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.347596179787406,
+      "Slug Place": "concord-ca"
+    },
+    {
+      "ID Place": "16000US0615044",
+      Place: "Compton, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.382000957395885,
+      "Slug Place": "compton-ca"
+    },
+    {
+      "ID Place": "16000US0613392",
+      Place: "Chula Vista, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 26.395102599432214,
+      "Slug Place": "chula-vista-ca"
+    },
+    {
+      "ID Place": "16000US0613014",
+      Place: "Chico, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 14.953906322748859,
+      "Slug Place": "chico-ca"
+    },
+    {
+      "ID Place": "16000US0608786",
+      Place: "Buena Park, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 29.272701722111503,
+      "Slug Place": "buena-park-ca"
+    },
+    {
+      "ID Place": "16000US5548000",
+      Place: "Madison, WI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.545086688554807,
+      "Slug Place": "madison-wi"
+    },
+    {
+      "ID Place": "16000US0606000",
+      Place: "Berkeley, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.33578875195584,
+      "Slug Place": "berkeley-ca"
+    },
+    {
+      "ID Place": "16000US0603526",
+      Place: "Bakersfield, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.68542317772203,
+      "Slug Place": "bakersfield-ca"
+    },
+    {
+      "ID Place": "16000US0602252",
+      Place: "Antioch, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 41.66217369816238,
+      "Slug Place": "antioch-ca"
+    },
+    {
+      "ID Place": "16000US0602000",
+      Place: "Anaheim, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 27.337338521400778,
+      "Slug Place": "anaheim-ca"
+    },
+    {
+      "ID Place": "16000US5553000",
+      Place: "Milwaukee, WI",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.145156632899933,
+      "Slug Place": "milwaukee-wi"
+    },
+    {
+      "ID Place": "16000US0600884",
+      Place: "Alhambra, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.412966700302725,
+      "Slug Place": "alhambra-ca"
+    },
+    {
+      "ID Place": "16000US0600562",
+      Place: "Alameda, CA",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 28.906316067653275,
+      "Slug Place": "alameda-ca"
+    },
+    {
+      "ID Place": "16000US0541000",
+      Place: "Little Rock, AR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.62000282987037,
+      "Slug Place": "little-rock-ar"
+    },
+    {
+      "ID Place": "16000US0477000",
+      Place: "Tucson, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 21.741796530238563,
+      "Slug Place": "tucson-az"
+    },
+    {
+      "ID Place": "16000US0473000",
+      Place: "Tempe, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.50118712868037,
+      "Slug Place": "tempe-az"
+    },
+    {
+      "ID Place": "16000US7206593",
+      Place: "Bayamón, PR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 34.70361469910884,
+      "Slug Place": "bayamón-pr"
+    },
+    {
+      "ID Place": "16000US0465000",
+      Place: "Scottsdale, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 18.52233979752769,
+      "Slug Place": "scottsdale-az"
+    },
+    {
+      "ID Place": "16000US0455000",
+      Place: "Phoenix, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 23.597831351959048,
+      "Slug Place": "phoenix-az"
+    },
+    {
+      "ID Place": "16000US0446000",
+      Place: "Mesa, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 24.006480123657404,
+      "Slug Place": "mesa-az"
+    },
+    {
+      "ID Place": "16000US0427820",
+      Place: "Glendale, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.710437675755298,
+      "Slug Place": "glendale-az"
+    },
+    {
+      "ID Place": "16000US7214290",
+      Place: "Carolina, PR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 31.05258099465278,
+      "Slug Place": "carolina-pr"
+    },
+    {
+      "ID Place": "16000US0427400",
+      Place: "Gilbert, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.1549588644788,
+      "Slug Place": "gilbert-az"
+    },
+    {
+      "ID Place": "16000US0423620",
+      Place: "Flagstaff, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 16.018971087730925,
+      "Slug Place": "flagstaff-az"
+    },
+    {
+      "ID Place": "16000US0412000",
+      Place: "Chandler, AZ",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 22.329575779139912,
+      "Slug Place": "chandler-az"
+    },
+    {
+      "ID Place": "16000US7276770",
+      Place: "San Juan, PR",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 25.54467949515046,
+      "Slug Place": "san-juan-pr"
+    },
+    {
+      "ID Place": "16000US0203000",
+      Place: "Anchorage, AK",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 19.12871493424085,
+      "Slug Place": "anchorage-ak"
+    },
+    {
+      "ID Place": "16000US0151000",
+      Place: "Montgomery, AL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.695663286051186,
+      "Slug Place": "montgomery-al"
+    },
+    {
+      "ID Place": "16000US0137000",
+      Place: "Huntsville, AL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 17.806805239179955,
+      "Slug Place": "huntsville-al"
+    },
+    {
+      "ID Place": "16000US0107000",
+      Place: "Birmingham, AL",
+      "ID Year": 2013,
+      Year: "2013",
+      "Average Commute Time": 20.520832166343645,
+      "Slug Place": "birmingham-al"
+    }
+  ],
+};
+
+const toSeed = [];
+
+const uniqueCities = dataUsa.data.reduce((result, current) => {
+  const foundCity = result.find(item => item.Place === current.Place);
+  if (foundCity === undefined) {
+    return result.concat([current]);
+  } else {
+    return result;
   }
-];
+}, []);
+
+uniqueCities.forEach(item => {
+  delete item.Year;
+  delete item["Slug Place"];
+  delete item["ID Year"];
+  delete item["ID Place"];
+});
+
+function getRandomInt(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+uniqueCities.forEach(city => {
+  toSeed.push({
+    name: city.Place,
+    cost_of_living: getRandomInt(50, 100),
+    avg_commute_time: city["Average Commute Time"]
+  });
+});
+
+module.exports = toSeed;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { User } = require("../models/user");
+const User = require("../models/user");
 const bcrypt = require("bcryptjs");
 const passport = require("passport");
 


### PR DESCRIPTION
# Description

Functions to remove all duplicate cities from datausa.io.
All average commute times are accurate with datausa.io.
Cost of living function is a random number generator from 50-100

Sample seeded data:

```
{
    name: 'Appleton, WI',
    cost_of_living: 80,
    avg_commute_time: 17.64625113372972
  },
  {
    name: 'Enterprise, NV',
    cost_of_living: 88,
    avg_commute_time: 20.77497781721384
  },
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] Local mongodb seeded and returning data successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
