### PR TITLE
Search endpoint now can be limited to any amount

### DIFF
--- a/routes/city.js
+++ b/routes/city.js
@@ -169,12 +169,13 @@ router.get("/topten-score_total", async (req, res) => {
 });
 
 router.post("/search", async (req, res) => {
+  const limit = req.query.limit ? parseInt(req.query.limit) : 50;
   const { searchTerm } = req.body;
 
   try {
     const searchResults = await City.find({
       $text: { $search: `\"${searchTerm}\"` }
-    });
+    }).limit(limit);
 
     if (searchResults.length) {
       res.status(200).json({


### PR DESCRIPTION
# Description
Search endpoint now can be limited to any amount, defaults to 50

POST `https://stagebe.letsmovehomie.com/city/search/?limit=10`
```
{
	"searchTerm": "new york"
}

```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [x] Testing endpoint locally with Insomnia

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
